### PR TITLE
find_file: file attributes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,9 +6,6 @@ jobs:
     docker:
       - image: rbrich/xcikit:debian-11
 
-    environment:
-      CONAN_REVISIONS_ENABLED: 1
-
     steps:
       - checkout
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ option(XCI_BUILD_EXAMPLES "Disable to skip building examples." ON)
 option(XCI_BUILD_TESTS "Disable to skip building tests." ON)
 option(XCI_BUILD_BENCHMARKS "Disable to skip building benchmarks." ON)
 
+# Dependencies
 option(XCI_WITH_TINFO "Link with TInfo (from NCurses) and use it for TTY control sequences." OFF)
 option(XCI_WITH_ZIP "Link xci-core with libzip and use it for ZIP format in VFS." OFF)
 
@@ -43,11 +44,7 @@ include(XciBuildOptions)
 # Dependencies #
 # ------------ #
 
-# Enable lookup for Conan dependencies
-if (EXISTS ${CMAKE_BINARY_DIR}/conan_paths.cmake)
-    include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
-endif()
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})
+include(ConanInit)
 
 if (XCI_TEXT)
     # RectangleBinPack (xci-text)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -53,12 +53,7 @@ if [[ ! -e "share/fonts/Hack/Hack-Regular.ttf" ]] ; then
     echo "=== Download Hack font ==="
     HACK_VERSION="v3.003"
     HACK_ARCHIVE="Hack-${HACK_VERSION}-ttf.tar.gz"
-    if [[ -e "/srv/${HACK_ARCHIVE}" ]] ; then
-        # downloaded in Dockerfile
-        cp "/srv/${HACK_ARCHIVE}" .
-    else
-        curl -LO "https://github.com/source-foundry/Hack/releases/download/${HACK_VERSION}/${HACK_ARCHIVE}"
-    fi
+    curl -LO "https://github.com/source-foundry/Hack/releases/download/${HACK_VERSION}/${HACK_ARCHIVE}"
     tar xf ${HACK_ARCHIVE} -C share/fonts
     mv share/fonts/ttf share/fonts/Hack
     rm ${HACK_ARCHIVE}

--- a/cmake/ConanInit.cmake
+++ b/cmake/ConanInit.cmake
@@ -1,0 +1,37 @@
+option(RUN_CONAN "Run 'conan install' from CMake (this may be more convenient than separate command)" OFF)
+
+# Run conan install directly
+if (RUN_CONAN)
+    if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
+        message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
+        file(DOWNLOAD "https://github.com/conan-io/cmake-conan/raw/v0.15/conan.cmake"
+            "${CMAKE_BINARY_DIR}/conan.cmake"
+            TLS_VERIFY ON
+            LOG dl_log
+            STATUS dl_status)
+        if (NOT 0 IN_LIST dl_status)
+            file(REMOVE "${CMAKE_BINARY_DIR}/conan.cmake")
+            message(STATUS "Download: ${dl_log}")
+            message(SEND_ERROR "Download failed: ${dl_status}")
+        endif()
+    endif()
+
+    include(${CMAKE_BINARY_DIR}/conan.cmake)
+
+    if (APPLE)
+        conan_cmake_run(
+            CONANFILE conanfile.py
+            SETTINGS os.version=${CMAKE_OSX_DEPLOYMENT_TARGET}
+            BUILD missing)
+    else()
+        conan_cmake_run(
+            CONANFILE conanfile.py
+            BUILD missing)
+    endif()
+endif()
+
+# Enable lookup for Conan dependencies
+if (EXISTS ${CMAKE_BINARY_DIR}/conan_paths.cmake)
+    include(${CMAKE_BINARY_DIR}/conan_paths.cmake)
+endif()
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_BINARY_DIR})

--- a/conanfile.py
+++ b/conanfile.py
@@ -21,7 +21,7 @@ class XcikitConan(ConanFile):
         'replxx/20200217@rbrich/stable',
         'magic_get/1.0.1@rbrich/stable',
         'magic_enum/0.6.6',
-        'fmt/7.0.1',
+        'fmt/7.0.3',
     )
     build_requires_or_preinstalled = (
         # <CMake name>, <min ver>,  <Conan reference>

--- a/docker/debian-11/Dockerfile
+++ b/docker/debian-11/Dockerfile
@@ -1,10 +1,14 @@
-# CI builder (public):
+# CI builder (public)
 #   docker build --target builder -t rbrich/xcikit:debian-11 docker/debian-11/
 #   docker run --rm -v $PWD:/xcikit -w /xcikit -it rbrich/xcikit:debian-11 bash
-# SSH builder (local, for Clion "Remote Host" toolchain):
+#
+# SSH builder (for Clion "Remote Host" toolchain)
+# see https://blog.jetbrains.com/clion/2020/01/using-docker-with-clion/)
 #   docker build --target builder-ssh --build-arg rootpw=pass1 -t xcikit-ssh:debian-11 docker/debian-11/
-#   docker run -p 222:22 -v $PWD:/xcikit --name xcikit-ssh -w /xcikit xcikit-ssh:debian-11
+#   docker run -p 127.0.0.1:222:22 --cap-add sys_ptrace --name xcikit-ssh xcikit-ssh:debian-11
 #   ssh root@localhost -p 222
+# Cleanup known hosts:
+#   ssh-keygen -f "$HOME/.ssh/known_hosts" -R "[localhost]:222"
 
 FROM debian:bullseye-slim AS builder
 
@@ -16,7 +20,8 @@ RUN echo "gcc 10"; apt-get update && apt-get install --no-install-recommends -y 
     update-alternatives --install /usr/bin/cc cc /usr/bin/gcc      50
 
 RUN echo "dev tools"; apt-get update && apt-get install --no-install-recommends -y \
-    cmake ninja-build python3-minimal libpython3-stdlib && rm -rf /var/lib/apt/lists/*
+    ca-certificates curl cmake ninja-build python3-minimal libpython3-stdlib && \
+    rm -rf /var/lib/apt/lists/*
 ENV CMAKE_GENERATOR=Ninja CONAN_CMAKE_GENERATOR=Ninja
 
 RUN echo "conan"; apt-get update && apt-mark manual $(apt-mark showauto) && \
@@ -25,29 +30,26 @@ RUN echo "conan"; apt-get update && apt-mark manual $(apt-mark showauto) && \
     conan profile new default --detect && \
     conan profile update "settings.compiler.libcxx=libstdc++11" default && \
     conan remote add xcikit https://api.bintray.com/conan/rbrich/xcikit && \
+    conan config set general.revisions_enabled=1 && \
     apt-get purge -y python3-pip $(apt-mark showauto) && \
     rm -rf /var/lib/apt/lists/*
-ENV CONAN_REVISIONS_ENABLED=1
 
 RUN echo "xcikit deps"; apt-get update && apt-get install --no-install-recommends -y \
     glslang-tools libvulkan-dev libfreetype6-dev librange-v3-dev \
     tao-pegtl-dev libhyperscan-dev catch2 libbenchmark-dev && rm -rf /var/lib/apt/lists/*
 
-ADD 'https://github.com/source-foundry/Hack/releases/download/v3.003/Hack-v3.003-ttf.tar.gz' /srv
 
+# --------------------------------------------------------------------------------------------------
 # https://docs.docker.com/engine/examples/running_ssh_service/
 FROM builder AS builder-ssh
 
 ARG rootpw
 
-RUN echo "ssh"; apt-get update && apt-get install --no-install-recommends -y openssh-server && \
-    echo "root:$rootpw" | chpasswd && mkdir /var/run/sshd && \
-    sed -i 's/#*PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config && \
-    sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd && \
-    printf '#!/bin/sh\nexit 0\n' > /usr/sbin/policy-rc.d
-
-# additional development tools
-RUN apt-get install --no-install-recommends -y git gdb make ca-certificates
+RUN apt-get update && apt-get install --no-install-recommends -y gdb git make rsync openssh-server
+RUN echo "root:$rootpw" | chpasswd && mkdir /run/sshd && \
+    echo 'PermitRootLogin yes' > "/etc/ssh/sshd_config.d/docker.conf"
 
 EXPOSE 22
-CMD ["/usr/sbin/sshd", "-D", "-d"]
+
+# -D    do not become a daemon
+CMD ["/usr/sbin/sshd", "-D"]

--- a/docker/debian-11/Dockerfile
+++ b/docker/debian-11/Dockerfile
@@ -1,7 +1,12 @@
-# docker build -t rbrich/xcikit:debian-11 docker/debian-11/
-# docker run --rm -v $PWD:/mnt/xcikit -it rbrich/xcikit:debian-11 bash
+# CI builder (public):
+#   docker build --target builder -t rbrich/xcikit:debian-11 docker/debian-11/
+#   docker run --rm -v $PWD:/xcikit -w /xcikit -it rbrich/xcikit:debian-11 bash
+# SSH builder (local, for Clion "Remote Host" toolchain):
+#   docker build --target builder-ssh --build-arg rootpw=pass1 -t xcikit-ssh:debian-11 docker/debian-11/
+#   docker run -p 222:22 -v $PWD:/xcikit --name xcikit-ssh -w /xcikit xcikit-ssh:debian-11
+#   ssh root@localhost -p 222
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-slim AS builder
 
 RUN echo "gcc 10"; apt-get update && apt-get install --no-install-recommends -y \
     g++-10 && rm -rf /var/lib/apt/lists/* && \
@@ -30,4 +35,19 @@ RUN echo "xcikit deps"; apt-get update && apt-get install --no-install-recommend
 
 ADD 'https://github.com/source-foundry/Hack/releases/download/v3.003/Hack-v3.003-ttf.tar.gz' /srv
 
-WORKDIR /mnt/xcikit
+# https://docs.docker.com/engine/examples/running_ssh_service/
+FROM builder AS builder-ssh
+
+ARG rootpw
+
+RUN echo "ssh"; apt-get update && apt-get install --no-install-recommends -y openssh-server && \
+    echo "root:$rootpw" | chpasswd && mkdir /var/run/sshd && \
+    sed -i 's/#*PermitRootLogin prohibit-password/PermitRootLogin yes/g' /etc/ssh/sshd_config && \
+    sed -i 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' /etc/pam.d/sshd && \
+    printf '#!/bin/sh\nexit 0\n' > /usr/sbin/policy-rc.d
+
+# additional development tools
+RUN apt-get install --no-install-recommends -y git gdb make ca-certificates
+
+EXPOSE 22
+CMD ["/usr/sbin/sshd", "-D", "-d"]

--- a/src/xci/core/FileTree.h
+++ b/src/xci/core/FileTree.h
@@ -77,9 +77,12 @@ public:
             int rc;
             if (fd == -1) {
                 assert(parent);  // don't call stat on incomplete PathNode
-                rc = fstatat(parent->fd, component.c_str(), &st, AT_SYMLINK_NOFOLLOW);
+                if (parent->fd == -1)
+                    rc = ::lstat(file_name().c_str(), &st);
+                else
+                    rc = ::fstatat(parent->fd, component.c_str(), &st, AT_SYMLINK_NOFOLLOW);
             } else {
-                rc = fstat(fd, &st);
+                rc = ::fstat(fd, &st);
             }
             return rc == 0;
         }

--- a/src/xci/core/TermCtl.cpp
+++ b/src/xci/core/TermCtl.cpp
@@ -55,6 +55,8 @@ inline std::string tparm(const char* seq, Args... args) { return fmt::format(seq
 #endif // XCI_WITH_TINFO
 
 // not found in Terminfo DB:
+static constexpr auto set_bright_foreground = CSI "1;3{}m";
+static constexpr auto set_bright_background = CSI "1;4{}m";
 static constexpr auto enter_overline_mode = CSI "53m";
 static constexpr auto send_soft_reset = CSI "!p";
 
@@ -168,12 +170,18 @@ void TermCtl::set_is_tty(IsTty is_tty)
 
 TermCtl TermCtl::fg(Color color) const
 {
-    return TERM_APPEND(set_a_foreground, static_cast<int>(color));
+    if (color < Color::BrightBlack)
+        return TERM_APPEND(set_a_foreground, static_cast<int>(color));
+    // bright colors
+    return TERM_APPEND(set_bright_foreground, static_cast<int>(color) - static_cast<int>(Color::BrightBlack));
 }
 
 TermCtl TermCtl::bg(Color color) const
 {
-    return TERM_APPEND(set_a_background, static_cast<int>(color));
+    if (color < Color::BrightBlack)
+        return TERM_APPEND(set_a_background, static_cast<int>(color));
+    // bright colors
+    return TERM_APPEND(set_bright_background, static_cast<int>(color) - static_cast<int>(Color::BrightBlack));
 }
 
 TermCtl TermCtl::mode(Mode mode) const

--- a/src/xci/core/TermCtl.cpp
+++ b/src/xci/core/TermCtl.cpp
@@ -40,6 +40,7 @@ static constexpr auto cursor_down = CSI "B";
 static constexpr auto cursor_right = CSI "C";
 static constexpr auto cursor_left = CSI "D";
 static constexpr auto enter_bold_mode = CSI "1m";
+static constexpr auto enter_dim_mode = CSI "2m";
 static constexpr auto enter_underline_mode = CSI "4m";
 static constexpr auto exit_attribute_mode = CSI "0m";
 static constexpr auto set_a_foreground = CSI "3{}m";
@@ -189,6 +190,7 @@ TermCtl TermCtl::mode(Mode mode) const
     switch (mode) {
         case Mode::Normal: return normal();
         case Mode::Bold: return bold();
+        case Mode::Dim: return dim();
         case Mode::Underline: return underline();
         case Mode::Overline: return overline();
     }
@@ -196,6 +198,7 @@ TermCtl TermCtl::mode(Mode mode) const
 }
 
 TermCtl TermCtl::bold() const { return TERM_APPEND(enter_bold_mode); }
+TermCtl TermCtl::dim() const { return TERM_APPEND(enter_dim_mode); }
 TermCtl TermCtl::underline() const { return TERM_APPEND(enter_underline_mode); }
 TermCtl TermCtl::overline() const { return TERM_APPEND(enter_overline_mode); }
 TermCtl TermCtl::normal() const { return TERM_APPEND(exit_attribute_mode); }

--- a/src/xci/core/TermCtl.h
+++ b/src/xci/core/TermCtl.h
@@ -52,7 +52,7 @@ public:
         BrightBlack, BrightRed, BrightGreen, BrightYellow,
         BrightBlue, BrightMagenta, BrightCyan, BrightWhite,
     };
-    enum class Mode { Normal, Bold, Underline, Overline };
+    enum class Mode { Normal, Bold, Dim, Underline, Overline };
 
     // foreground
     TermCtl fg(Color color) const;
@@ -78,7 +78,8 @@ public:
 
     // mode
     TermCtl mode(Mode mode) const;
-    TermCtl bold() const;
+    TermCtl bold() const;  // bold and/or increased intensity
+    TermCtl dim() const;  // decreased intensity
     TermCtl underline() const;
     TermCtl overline() const;
     TermCtl normal() const;  // reset all attributes

--- a/src/xci/core/TermCtl.h
+++ b/src/xci/core/TermCtl.h
@@ -7,7 +7,7 @@
 #ifndef XCI_CORE_TERM_H
 #define XCI_CORE_TERM_H
 
-#include <fmt/core.h>
+#include <fmt/format.h>
 #include <string>
 #include <ostream>
 
@@ -47,7 +47,11 @@ public:
     // Following methods are appending the capability codes
     // to a copy of TermCtl instance, which can then be send to stream
 
-    enum class Color { Black, Red, Green, Yellow, Blue, Magenta, Cyan, White };
+    enum class Color {
+        Black, Red, Green, Yellow, Blue, Magenta, Cyan, White,
+        BrightBlack, BrightRed, BrightGreen, BrightYellow,
+        BrightBlue, BrightMagenta, BrightCyan, BrightWhite,
+    };
     enum class Mode { Normal, Bold, Underline, Overline };
 
     // foreground
@@ -185,6 +189,23 @@ struct [[maybe_unused]] fmt::formatter<T, Char, Enable> {
     auto format(const T& p, FormatContext& ctx) {
         auto msg = p.seq(value);
         return std::copy(msg.begin(), msg.end(), ctx.out());
+    }
+};
+
+
+// support `term.bold()` etc. directly in format args
+template <>
+struct [[maybe_unused]] fmt::formatter<xci::core::TermCtl> {
+    constexpr auto parse(format_parse_context& ctx) {
+        auto it = ctx.begin();  // NOLINT
+        if (it != ctx.end() && *it != '}')
+            throw fmt::format_error("invalid format for TermCtl");
+        return it;
+    }
+
+    template <typename FormatContext>
+    auto format(const xci::core::TermCtl& term, FormatContext& ctx) {
+        return std::copy(term.seq().cbegin(), term.seq().cend(), ctx.out());
     }
 };
 

--- a/src/xci/core/memoization.h
+++ b/src/xci/core/memoization.h
@@ -1,0 +1,70 @@
+// memoization.h created on 2020-10-17 as part of xcikit project
+// https://github.com/rbrich/xcikit
+//
+// Copyright 2020 Radek Brich
+// Licensed under the Apache License, Version 2.0 (see LICENSE file)
+
+/// https://en.wikibooks.org/wiki/Optimizing_C%2B%2B/General_optimization_techniques/Memoization
+
+#ifndef XCI_CORE_MEMOIZATION_H
+#define XCI_CORE_MEMOIZATION_H
+
+#include <tuple>
+
+namespace xci::core {
+
+
+/// Represents memoized function. Stores the function itself
+/// and `n` cells for memoization of different function args.
+/// Do not construct directly, use memoize() function instead.
+template <unsigned n, typename Func, typename Ret, typename... Args>
+class Memoized {
+public:
+    explicit Memoized(Func func): func(func) {}
+
+    Ret operator() (Args... args)
+    {
+        // On first call:
+        // - field #0 is initialized to result of calling func with default-constructed args
+        // - reading starts with this pre-initialized field #0
+        // - if not matched, new item is written to field #1
+        // On following calls:
+        // - check recent items (backwards)
+        // - write new items to uninitialized fields
+        // - field #0 (default value) is overwritten last
+        // - until all items are overwritten, lookup always goes through default in field #0
+
+        int i = last_read_i;
+        do {
+            if (memo_args[i] == std::tuple<Args...>{args...})
+                return memo_result[i];
+            i = (i - 1 + n) % n;
+        } while (i != last_read_i);
+
+        i = (last_written_i + 1) % n;
+        last_read_i = last_written_i = i;
+        memo_args[i] = {args...};
+        return memo_result[i] = func(args...);
+    }
+
+private:
+    Func func;
+    std::tuple<Args...> memo_args[n] {};
+    Ret memo_result[n] {func(Args{}...)};
+    int last_read_i = 0;
+    int last_written_i = 0;
+};
+
+
+/// Make function object for memoization of `func`.
+/// \tparam n       How many most-recent results should be remembered.
+/// \param func     The function to be memoized and called by Memoized function object.
+template<unsigned n = 8, typename Ret, typename... Args>
+auto memoize(Ret (*func)(Args...)) {
+    return Memoized<n, decltype(func), Ret, Args...>{func};
+}
+
+
+} // namespace xci::core
+
+#endif // include guard

--- a/src/xci/core/sys.cpp
+++ b/src/xci/core/sys.cpp
@@ -26,6 +26,7 @@
 #else
     #include <sys/types.h>
     #include <pwd.h>
+    #include <grp.h>
 #endif
 
 namespace xci::core {
@@ -106,6 +107,34 @@ std::string get_home_dir()
     }
 
     return {result->pw_dir};
+#endif
+}
+
+
+std::string uid_to_user_name(uid_t uid)
+{
+#ifndef _WIN32
+    struct passwd* pwd = getpwuid(uid);
+    if (pwd == nullptr)
+        return std::to_string(uid);
+    return pwd->pw_name;
+#else
+    assert(!"not implemented");
+    return {};
+#endif
+}
+
+
+std::string gid_to_group_name(gid_t gid)
+{
+#ifndef _WIN32
+    struct group* grp = getgrgid(gid);
+    if (grp == nullptr)
+        return std::to_string(gid);
+    return grp->gr_name;
+#else
+    assert(!"not implemented");
+    return {};
 #endif
 }
 

--- a/src/xci/core/sys.cpp
+++ b/src/xci/core/sys.cpp
@@ -111,32 +111,24 @@ std::string get_home_dir()
 }
 
 
+#ifndef _WIN32
 std::string uid_to_user_name(uid_t uid)
 {
-#ifndef _WIN32
     struct passwd* pwd = getpwuid(uid);
     if (pwd == nullptr)
         return std::to_string(uid);
     return pwd->pw_name;
-#else
-    assert(!"not implemented");
-    return {};
-#endif
 }
 
 
 std::string gid_to_group_name(gid_t gid)
 {
-#ifndef _WIN32
     struct group* grp = getgrgid(gid);
     if (grp == nullptr)
         return std::to_string(gid);
     return grp->gr_name;
-#else
-    assert(!"not implemented");
-    return {};
-#endif
 }
+#endif  // _WIN32
 
 
 std::string errno_str()

--- a/src/xci/core/sys.h
+++ b/src/xci/core/sys.h
@@ -63,8 +63,10 @@ int pending_signals(std::initializer_list<int> signums);
 /// \return             the home dir or in case of error "/tmp"
 std::string get_home_dir();
 
+#ifndef _WIN32
 std::string uid_to_user_name(uid_t uid);
 std::string gid_to_group_name(gid_t gid);
+#endif
 
 /// Retrieve absolute file path of currently running process.
 std::string get_self_path();

--- a/src/xci/core/sys.h
+++ b/src/xci/core/sys.h
@@ -12,7 +12,7 @@
 #include <cstdint>
 #include <csignal>
 
-#ifdef __linux__
+#ifndef _WIN32
 #include <sys/types.h>
 #endif
 
@@ -62,6 +62,9 @@ int pending_signals(std::initializer_list<int> signums);
 /// Retrieve home dir of current user from password file (i.e. /etc/passwd).
 /// \return             the home dir or in case of error "/tmp"
 std::string get_home_dir();
+
+std::string uid_to_user_name(uid_t uid);
+std::string gid_to_group_name(gid_t gid);
 
 /// Retrieve absolute file path of currently running process.
 std::string get_self_path();


### PR DESCRIPTION
New options to show / filter file attributes:
```
  -l, --long                    Print file attributes
  -t, --types TYPES             Filter file types: r=regular, d=dir, l=link, s=sock, f=fifo, c=char, b=block, e.g. -tdl for dir+link (implies -D)
```
Both of them need additional `stat(2)` call for each **matched** file.

Also added color output related options:
```
  -C, --no-color                Disable color output (default: auto)
  -M, --no-highlight            Don't highlight matches (default: enabled for color output)
```