### PR TITLE
ArgParser: wrap --help to 120 or less columns

### DIFF
--- a/src/xci/core/ArgParser.h
+++ b/src/xci/core/ArgParser.h
@@ -1,7 +1,7 @@
 // ArgParser.h created on 2019-06-04 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2019, 2020 Radek Brich
+// Copyright 2019, 2020, 2021 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_CORE_ARG_PARSER_H
@@ -278,10 +278,12 @@ public:
     ParseResult parse_arg(const char* argv[]);
 
     /// Print short usage information
-    void print_usage() const;
+    /// \param max_width    Wrap lines when reaching this number of columns. 0 = no wrapping
+    void print_usage(unsigned max_width = 100) const;
 
     /// Print help text
-    void print_help() const;
+    /// \param max_width    Wrap lines when reaching this number of columns. 0 = no wrapping
+    void print_help(unsigned max_width = 100) const;
 
     /// Print information how to invoke help
     void print_help_notice() const;

--- a/src/xci/core/ArgParser.h
+++ b/src/xci/core/ArgParser.h
@@ -247,9 +247,14 @@ public:
     /// It will fail on missing arguments of trailing options.
     /// For incremental parsing, see `parse_args` below.
     ///
-    /// \param argv     argv argument from main() function, i.e. program name,
-    ///                 followed by args, followed by NULL terminator
-    ArgParser& operator()(const char* argv[]);
+    /// \param argv         Pass argv from main() function, i.e. program name,
+    ///                     followed by args, followed by NULL terminator.
+    /// \param detect_width When enabled, try to detect actual terminal width
+    ///                     and further limit max_width to the detected width.
+    ///                     If the detected width is less than 80, limit to 80.
+    /// \param max_width    Max width in columns for help and usage text.
+    ///                     Set to 0 to disable wrapping.
+    ArgParser& operator()(const char* argv[], bool detect_width = true, unsigned max_width = 120);
     ArgParser& operator()(char* argv[]) { return operator()((const char**) argv); }
 
     enum ParseResult {
@@ -278,12 +283,10 @@ public:
     ParseResult parse_arg(const char* argv[]);
 
     /// Print short usage information
-    /// \param max_width    Wrap lines when reaching this number of columns. 0 = no wrapping
-    void print_usage(unsigned max_width = 100) const;
+    void print_usage() const;
 
     /// Print help text
-    /// \param max_width    Wrap lines when reaching this number of columns. 0 = no wrapping
-    void print_help(unsigned max_width = 100) const;
+    void print_help() const;
 
     /// Print information how to invoke help
     void print_help_notice() const;
@@ -294,6 +297,7 @@ private:
     std::string m_progname;
     std::vector<Option> m_opts;
     Option* m_curopt = nullptr;
+    unsigned m_max_width = ~0u;
     bool m_awaiting_arg = false;
 };
 

--- a/src/xci/core/TermCtl.cpp
+++ b/src/xci/core/TermCtl.cpp
@@ -19,6 +19,7 @@
     static_assert(sizeof(unsigned long) == sizeof(DWORD));
 #else
     #include <termios.h>
+    #include <sys/ioctl.h>
 #endif
 
 #ifdef XCI_WITH_TINFO
@@ -161,6 +162,20 @@ void TermCtl::set_is_tty(IsTty is_tty)
     #endif
 
     m_state = State::InitOk;
+#endif
+}
+
+
+auto TermCtl::size() const -> Size
+{
+#ifndef _WIN32
+    struct winsize ws;
+    if (ioctl(m_fd, TIOCGWINSZ, &ws) == -1) {
+        return {0, 0};
+    }
+    return {ws.ws_row, ws.ws_col};
+#else
+    return {0, 0};
 #endif
 }
 
@@ -355,7 +370,7 @@ unsigned int TermCtl::stripped_length(std::string_view s)
         }
     }
     return length;
-};
+}
 
 
 } // namespace xci::core

--- a/src/xci/core/TermCtl.cpp
+++ b/src/xci/core/TermCtl.cpp
@@ -1,7 +1,7 @@
 // TermCtl.cpp created on 2018-07-09 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2020 Radek Brich
+// Copyright 2018, 2020, 2021 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 // References:
@@ -322,6 +322,40 @@ void TermCtl::print(const std::string& buf)
 {
     ::write(m_fd, buf.data(), buf.size());
 }
+
+
+unsigned int TermCtl::stripped_length(std::string_view s)
+{
+    enum State {
+        Visible,
+        Esc,
+        Csi,
+    } state = Visible;
+    unsigned int length = 0;
+    for (const auto c : s) {
+        switch (state) {
+            case Visible:
+                if (c == '\033')
+                    state = Esc;
+                else
+                    ++length;
+                break;
+
+            case Esc:
+                if (c == '[')
+                    state = Csi;
+                else
+                    state = Visible;
+                break;
+
+            case Csi:
+                if (isalpha(c))
+                    state = Visible;
+                break;
+        }
+    }
+    return length;
+};
 
 
 } // namespace xci::core

--- a/src/xci/core/TermCtl.h
+++ b/src/xci/core/TermCtl.h
@@ -1,7 +1,7 @@
 // TermCtl.h created on 2018-07-09 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2020 Radek Brich
+// Copyright 2018, 2020, 2021 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_CORE_TERM_H
@@ -136,6 +136,9 @@ public:
         auto buf = format(fmt, std::forward<Args>(args)...);
         print(buf);
     }
+
+    /// Compute length of `s` when stripped of terminal control sequences and invisible characters
+    static unsigned int stripped_length(std::string_view s);
 
     // Temporarily change terminal mode to RAW mode
     // (no echo, no buffering, no special processing)

--- a/src/xci/core/TermCtl.h
+++ b/src/xci/core/TermCtl.h
@@ -44,6 +44,13 @@ public:
     // - Never: false
     [[nodiscard]] bool is_tty() const { return m_state != State::NoTTY; }
 
+    // Detect terminal size, return {0,0} if not detected
+    struct Size {
+        unsigned short rows;
+        unsigned short cols;
+    };
+    Size size() const;
+
     // Following methods are appending the capability codes
     // to a copy of TermCtl instance, which can then be send to stream
 


### PR DESCRIPTION
The `max_width` parameter can be changed when calling ArgParser. Default is 120 columns. Actual terminal width is detected and the width is also limited to that. Minimal width is 80 columns (hardcoded).