### PR TITLE
[script] Raw string literals

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -46,7 +46,7 @@ class XcikitConan(ConanFile):
     build_requires_or_preinstalled = (
         # <CMake name>, <min ver>,  <Conan reference>       <option>
         ('range-v3',    '0.10.0',   'range-v3/0.11.0',      None),
-        ('Catch2',      '',         'catch2/2.13.4',        'tests'),
+        ('Catch2',      '',         'catch2/2.13.6',        'tests'),
         ('benchmark',   '',         'benchmark/1.5.2',      'benchmarks'),
         ('pegtl',       '3.1.0',    'taocpp-pegtl/3.1.0',   None),
         ('glfw3',       '3.2.1',    'glfw/3.3.2',           'graphics'),

--- a/docs/script/syntax.adoc
+++ b/docs/script/syntax.adoc
@@ -78,38 +78,42 @@ The raw string can be multi-line. It has a few special rules:
   i.e. add a newline after the backslash and another one after opening quotes
   (they'll both be removed).
 
+[source,fire]
 ----
-a = """Hello"""   // `Hello`
+a = """Hello"""     // `Hello`
 b = """
-    Hello
-    """           // `Hello`
+    stripped
+    """             // `stripped`
 c = """
-    \nHello\0
-    """           // `\nHello\0`
+    \n\0\ <- not special
+    """             // `\n\0\ <- not special`
 d = """
-    Hello
-"""               // `    Hello`
-e = """Hello
-"""               // `Hello<nl>`
-f = """
-    Hello"""      // `<nl>    Hello`
+    no indent removal
+"""                 // `    no indent removal`
+e = """
+    partial indent removal
+  """               // `  partial indent removal`
+f = """not stripped
+"""                 // `not stripped<nl>`
 g = """
-
-Hello
-
-"""               // `<nl>Hello<nl>`
+    not stripped""" // `<nl>    not stripped`
 h = """
-    \""""Hello\""""
-    """           // `""""Hello""""`
+
+first/last nl stripped
+
+"""                 // `<nl>first/last nl stripped<nl>`
 i = """
+    \""""escaped quotes\""""
+    """             // `""""escaped quotes""""`
+j = """
     \""""
     \\""""
     \\\""""
-    """           // `""""<nl>\""""<nl>\\""""`
-j = """\"""       // ERROR: unclosed
-k = """
+    """             // `""""<nl>\""""<nl>\\""""`
+k = """\""" <- escaped! """
+l = """
 \
-"""               // `\`
+"""                 // `\` (trailing backslash requires multi-line)
 ----
 
 

--- a/docs/script/syntax.adoc
+++ b/docs/script/syntax.adoc
@@ -53,19 +53,65 @@ b'@'       // byte / ASCII character
 42b        // byte (8bit integer, unsigned)
 "lava"     // string (UTF-8)
 b"lava"    // bytes (ASCII string)
-r"raw\n"   // raw string
-rb"raw"    // raw bytes
-"""abc"""  // multi-line string
-r"""abc""" // raw multi-line string
+"""abc"""  // raw string (here doc)
+b"""abc""" // raw bytes
 [1, 2, 3]  // list
 []:[Byte]  // empty list (type can be specified or inferred from context)
 {}         // empty block, effectively Void
 void       // empty statement, returns Void -> noop
 ----
 
-Raw strings are not completely raw, quotes still need to be escaped, by doubling them.
-The multi-line raw string is completely raw, but can't contain a sequence of three quotes.
-It can contain a sequence of less or more than three quotes, though.
+The raw string can be multi-line. It has a few special rules:
+
+* Any whitespace followed by a newline after opening quotes,
+  and a newline followed by whitespace immediately before closing quotes,
+  are removed, when they appear together. If it's only one or the other end,
+  no whitespace or newlines are removed.
+
+* If the previous rule is satisfied, uniform indentation up to the level of
+  the closing quotes is removed.
+
+* A sequence of three or more quotes inside the raw string can be escaped
+  with a backslash: `\"""` => `"""`. Other backslashes are kept verbatim:
+  `\\"""` => `\"""`. A backslash right before ending quotes is not possible,
+  it would be interpreted as escaping the quotes. Instead, use the first rule,
+  i.e. add a newline after the backslash and another one after opening quotes
+  (they'll both be removed).
+
+----
+a = """Hello"""   // `Hello`
+b = """
+    Hello
+    """           // `Hello`
+c = """
+    \nHello\0
+    """           // `\nHello\0`
+d = """
+    Hello
+"""               // `    Hello`
+e = """Hello
+"""               // `Hello<nl>`
+f = """
+    Hello"""      // `<nl>    Hello`
+g = """
+
+Hello
+
+"""               // `<nl>Hello<nl>`
+h = """
+    \""""Hello\""""
+    """           // `""""Hello""""`
+i = """
+    \""""
+    \\""""
+    \\\""""
+    """           // `""""<nl>\""""<nl>\\""""`
+j = """\"""       // ERROR: unclosed
+k = """
+\
+"""               // `\`
+----
+
 
 === Scoped block
 

--- a/extras/pygments_fire_lexer/setup.py
+++ b/extras/pygments_fire_lexer/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='fire_lexer',
-    version="0.1",
+    version="0.2",
     packages=['fire_lexer'],
     entry_points=
     """

--- a/src/xci/core/EditLine.cpp
+++ b/src/xci/core/EditLine.cpp
@@ -314,12 +314,12 @@ void EditLine::process_input()
         for (const auto line : xci::core::split(content, '\n')) {
             if (line.data() != content.data()) {
                 // not the first line
-                write("\r\n" + std::string(m_prompt_len, ' '));
+                write("\n" + tout.move_to_column(m_prompt_len).seq());
                 ++m_cursor_line;
             }
             write(line);
             if (!cursor_found) {
-                auto part_len = tout.stripped_width(line);
+                auto part_len = TermCtl::stripped_width(line);
                 if (cursor > part_len) {
                     cursor -= part_len + 1;  // add 1 for '\n'
                 } else {

--- a/src/xci/core/parser/unescape.h
+++ b/src/xci/core/parser/unescape.h
@@ -18,8 +18,8 @@ struct StringChIllEsc : seq< one< '\\' >, sor<StringChIll, eof> > {};
 struct String: star< sor<try_catch<StringCh>, StringChIllEsc, StringChIll> > {};
 
 template< typename Rule > struct Action {};
-template<> struct Action<StringChOther> : StringAppend {};
-template<> struct Action<StringChIll> : StringAppend {};
+template<> struct Action<StringChOther> : StringAppendChar {};
+template<> struct Action<StringChIll> : StringAppendChar {};
 template<> struct Action<StringChEscSingle> : StringAppendEscSingle {};
 template<> struct Action<StringChEscHex> : StringAppendEscHex {};
 template<> struct Action<StringChEscOct> : StringAppendEscOct {};

--- a/src/xci/core/parser/unescape_rules.h
+++ b/src/xci/core/parser/unescape_rules.h
@@ -22,11 +22,9 @@ struct StringChOther : sor< one<'\t'>, not_range<0, 31> > {};
 struct StringCh : sor< StringChEsc, StringChOther > {};
 
 
-struct StringAppend {
+struct StringAppendChar {
     template<typename Input, typename String, typename... States>
     static void apply(const Input &in, String& str, States&&...) {
-        if (str.capacity() == str.size())
-            str.reserve(str.capacity() * 3 / 2);
         str.append(in.begin(), in.end());
     }
 };
@@ -35,8 +33,6 @@ struct StringAppend {
 struct StringAppendEscSingle {
     template<typename Input, typename String, typename... States>
     static void apply(const Input &in, String& str, States&&...) {
-        if (str.capacity() == str.size())
-            str.reserve(str.capacity() * 3 / 2);
         assert( in.size() == 1 );
         char ch = *in.begin();
         switch (ch) {
@@ -58,8 +54,6 @@ struct StringAppendEscSingle {
 struct StringAppendEscHex {
     template<typename Input, typename String, typename... States>
     static void apply(const Input &in, String& str, States&&...) {
-        if (str.capacity() == str.size())
-            str.reserve(str.capacity() * 3 / 2);
         assert( in.size() == 3 );
         str += (char) std::stoi(String{in.begin()+1, in.end()}, nullptr, 16);
     }
@@ -69,8 +63,6 @@ struct StringAppendEscHex {
 struct StringAppendEscOct {
     template<typename Input, typename String, typename... States>
     static void apply(const Input &in, String& str, States&&...) {
-        if (str.capacity() == str.size())
-            str.reserve(str.capacity() * 3 / 2);
         assert( in.size() >= 1 && in.size() <= 3 );
         str += (char) std::stoi(in.string(), nullptr, 8);
     }

--- a/src/xci/core/string.cpp
+++ b/src/xci/core/string.cpp
@@ -42,6 +42,25 @@ bool remove_suffix(string& str, const string& suffix)
 }
 
 
+std::string replace_all(std::string_view str, std::string_view substring, std::string_view replacement)
+{
+    std::string output;
+    size_t pos = 0;
+    auto end = str.cbegin();
+    for(;;) {
+        pos = str.find(substring, pos);
+        if (pos == std::string::npos)
+            break;
+        output.append(end, str.cbegin() + pos);
+        output += replacement;
+        pos += substring.size();
+        end = str.cbegin() + pos;
+    }
+    output.append(end, str.cend());
+    return output;
+}
+
+
 vector<string_view> split(string_view str, char delim, int maxsplit)
 {
     std::vector<string_view> res;

--- a/src/xci/core/string.h
+++ b/src/xci/core/string.h
@@ -25,6 +25,13 @@ bool remove_prefix(std::string& str, const std::string& prefix);
 
 bool remove_suffix(std::string& str, const std::string& suffix);
 
+/// Replace all occurrences of substring by replacement.
+std::string replace_all(std::string_view str, std::string_view substring, std::string_view replacement);
+
+/// Append `indentation` spaces after each newline.
+inline std::string indent(std::string_view str, unsigned indentation) {
+    return replace_all(str, "\n", "\n" + std::string(indentation, ' '));
+}
 
 std::vector<std::string_view> split(std::string_view str, char delim, int maxsplit = -1);
 std::vector<std::string_view> rsplit(std::string_view str, char delim, int maxsplit = -1);

--- a/src/xci/script/CMakeLists.txt
+++ b/src/xci/script/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(xci-script
     ast/resolve_nonlocals.cpp
     ast/resolve_symbols.cpp
     ast/resolve_types.cpp
+    parser/raw_string.cpp
     Builtin.cpp
     Class.cpp
     Code.cpp

--- a/src/xci/script/Parser.cpp
+++ b/src/xci/script/Parser.cpp
@@ -106,10 +106,12 @@ struct NumSuffix: one<'l', 'L', 'f', 'F', 'b', 'B'> {};
 struct Number: seq< opt<Sign>, sor<ZeroPrefixNum, DecNum>, opt<NumSuffix> > {};
 
 struct Char: if_must< one<'\''>, StringCh, one<'\''> > {};
-struct String: if_must< one<'"'>, until<one<'"'>, StringCh > > {};
+struct StringContent: until< one<'"'>, StringCh > {};
+struct String: if_must< one<'"'>, StringContent > {};
 struct EscapedQuotes: seq<one<'\\'>, three<'"'>, star<one<'"'>>> {};
 struct RawStringCh: any {};
-struct RawString : if_must< three<'"'>, until<three<'"'>, sor<EscapedQuotes, RawStringCh>> > {};
+struct RawStringContent: until<three<'"'>, sor<EscapedQuotes, RawStringCh>> {};
+struct RawString : if_must< three<'"'>, RawStringContent > {};
 struct Byte: seq< one<'b'>, Char > {};
 struct Bytes: seq< one<'b'>, String > {};
 struct RawBytes: seq< one<'b'>, RawString > {};
@@ -1225,6 +1227,8 @@ template<> const std::string Control<Variable>::errmsg = "expected variable name
 template<> const std::string Control<UnsafeType>::errmsg = "expected type";
 template<> const std::string Control<Type>::errmsg = "expected type";
 template<> const std::string Control<TypeName>::errmsg = "expected type name";
+template<> const std::string Control<StringContent>::errmsg = "unclosed string literal";
+template<> const std::string Control<RawStringContent>::errmsg = "unclosed raw string literal";
 
 // default message
 template< typename T >

--- a/src/xci/script/Parser.cpp
+++ b/src/xci/script/Parser.cpp
@@ -7,10 +7,10 @@
 #include "Parser.h"
 #include "Error.h"
 #include "TypeInfo.h"
+#include "parser/raw_string.h"
 #include <xci/core/parser/unescape_rules.h>
 
 #include <tao/pegtl.hpp>
-#include <tao/pegtl/contrib/raw_string.hpp>
 
 #ifndef NDEBUG
 #include <tao/pegtl/contrib/analyze.hpp>
@@ -107,10 +107,13 @@ struct Number: seq< opt<Sign>, sor<ZeroPrefixNum, DecNum>, opt<NumSuffix> > {};
 
 struct Char: if_must< one<'\''>, StringCh, one<'\''> > {};
 struct String: if_must< one<'"'>, until<one<'"'>, StringCh > > {};
+struct EscapedQuotes: seq<one<'\\'>, three<'"'>, star<one<'"'>>> {};
+struct RawStringCh: any {};
+struct RawString : if_must< three<'"'>, until<three<'"'>, sor<EscapedQuotes, RawStringCh>> > {};
 struct Byte: seq< one<'b'>, Char > {};
 struct Bytes: seq< one<'b'>, String > {};
-struct RawString : raw_string< '$', '-', '$' > {};  // raw_string = $$ raw text! $$
-struct Literal: sor< Char, String, Byte, Bytes, Number, RawString > {};
+struct RawBytes: seq< one<'b'>, RawString > {};
+struct Literal: sor< Char, RawString, String, Byte, RawBytes, Bytes, Number > {};
 
 // Types
 struct Parameter: sor< Type, seq< Identifier, opt<SC, one<':'>, SC, must<Type> > > > {};
@@ -1070,18 +1073,37 @@ struct Action<Bytes> {
 };
 
 
-template<> struct Action<StringChOther> : StringAppend {};
+template<> struct Action<StringChOther> : StringAppendChar {};
 template<> struct Action<StringChEscSingle> : StringAppendEscSingle {};
 template<> struct Action<StringChEscHex> : StringAppendEscHex {};
 template<> struct Action<StringChEscOct> : StringAppendEscOct {};
 
+template<> struct Action<RawStringCh> : StringAppendChar {};
 
 template<>
-struct Action<RawString::content> {
-    template<typename Input, typename States>
-    static void apply(const Input &in, const States& /* raw_string states */, LiteralHelper& helper) {
-        helper.content = in.string_view();
+struct Action<EscapedQuotes> {
+    template<typename Input>
+    static void apply(const Input &in, std::string& str) {
+        assert(in.size() >= 4);
+        str.append(in.begin() + 1, in.end());
+    }
+};
+
+template<>
+struct Action<RawString> : change_states< std::string > {
+    template<typename Input>
+    static void success(const Input &in, std::string& str, LiteralHelper& helper) {
+        helper.content = strip_raw_string(move(str));
         helper.type = ValueType::String;
+    }
+};
+
+
+template<>
+struct Action<RawBytes> {
+    template<typename Input>
+    static void apply(const Input &in, LiteralHelper& helper) {
+        helper.type = ValueType::List;  // [Byte]
     }
 };
 

--- a/src/xci/script/parser/raw_string.cpp
+++ b/src/xci/script/parser/raw_string.cpp
@@ -1,0 +1,79 @@
+// raw_string.cpp created on 2021-05-06 as part of xcikit project
+// https://github.com/rbrich/xcikit
+//
+// Copyright 2021 Radek Brich
+// Licensed under the Apache License, Version 2.0 (see LICENSE file)
+
+#include "raw_string.h"
+
+namespace xci::script {
+
+using std::move;
+
+
+/// Skip spaces and tabs, success on a newline, fail on any other char
+/// \returns 0 = fail, >0 success (a number of leading blanks including the newline)
+template <typename Iter>
+size_t count_leading_ws(Iter begin, Iter end)
+{
+    size_t leading_ws = 0;
+    auto it = begin;
+    while (it != end) {
+        if (*it == '\n')
+            return ++leading_ws;
+        if (isblank(*it)) {
+            ++leading_ws;
+            ++it;
+            continue;
+        }
+        return 0;
+    }
+    return leading_ws;
+}
+
+
+std::string strip_raw_string(std::string&& content)
+{
+    const size_t leading_ws = count_leading_ws(content.begin(), content.end());
+    const size_t trailing_ws = count_leading_ws(content.rbegin(), content.rend());
+    if (leading_ws == 0 || trailing_ws == 0)
+        return move(content);
+
+    // remove leading and trailing whitespace
+    content.erase(0, leading_ws);
+    content.erase(content.size() - trailing_ws);
+
+    // check uniform indentation
+    const size_t indentation = trailing_ws - 1;
+    if (indentation == 0)
+        return move(content);
+
+    auto it = content.cbegin();
+    const auto end = content.cbegin() + ptrdiff_t(content.size());
+    while (it != end) {
+        size_t need_indent = indentation;
+        while (need_indent > 0 && isblank(*it)) {
+            --need_indent;
+            ++it;
+        }
+        if (need_indent != 0)
+            return move(content);  // line not indented enough, abort
+        while (it != end && *it++ != '\n')
+            ;
+    }
+
+    // remove uniform indentation
+    it = content.cbegin();
+    std::string out;
+    while (it != end) {
+        auto newline = it;
+        while (newline != end && *newline++ != '\n')
+            ;
+        out.append(it + ptrdiff_t(indentation), newline);
+        it = newline;
+    }
+    return out;
+}
+
+
+} // namespace xci::script

--- a/src/xci/script/parser/raw_string.h
+++ b/src/xci/script/parser/raw_string.h
@@ -1,0 +1,21 @@
+// raw_string.h created on 2021-05-06 as part of xcikit project
+// https://github.com/rbrich/xcikit
+//
+// Copyright 2021 Radek Brich
+// Licensed under the Apache License, Version 2.0 (see LICENSE file)
+
+#ifndef XCI_SCRIPT_PARSER_RAW_STRING_H
+#define XCI_SCRIPT_PARSER_RAW_STRING_H
+
+#include <string>
+
+namespace xci::script {
+
+
+std::string strip_raw_string(std::string&& content);
+
+
+} // namespace xci::script
+
+
+#endif  // include guard

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -44,6 +44,24 @@ std::string parse(const string& input)
 }
 
 
+// Format parser input/output by hand, don't use Catch2's automatic expansion.
+// This is easier to read in the log and it also workarounds a bug in MSVC:
+//    CHECK(parse(R"("escape sequences: \"\n\0\x12 ")", R"("escape sequences: \"\n\0\x12 ")"));
+//    > error C2017: illegal escape sequence
+//    > error C2146: syntax error: missing ')' before identifier 'n'
+#define PARSE(input, expected)                          \
+    do {                                                \
+        auto output = parse(input);                     \
+        INFO("Input:    " << indent((input), 12));      \
+        INFO("Output:   " << indent((output), 12));     \
+        INFO("Expected: " << indent((expected), 12));   \
+        if ((output) == (expected))                     \
+            SUCCEED();                                  \
+        else                                            \
+            FAIL();                                     \
+    } while(false)
+
+
 std::string interpret(const string& input, bool import_std=false)
 {
     Interpreter interpreter;
@@ -127,13 +145,12 @@ TEST_CASE( "Values", "[script][parser]" )
     CHECK(parse("1.23") == "1.23");
     CHECK(parse("42b") == "b'*'");  // byte (8-bit integer)
     CHECK(parse("b'B'") == "b'B'");
-    CHECK(parse("b\"bytes literal\"") == "b\"bytes literal\"");
+    PARSE(R"(b"bytes literal")", R"(b"bytes literal")");
     CHECK(parse("'c'") == "'c'");
-    CHECK(parse("\"string literal\"") == "\"string literal\"");
-    // Note: don't use raw string literal, it causes MSVC Error C2017 due to stringize operation in Catch2
-    CHECK(parse("\"escape sequences: \\\"\\n\\0\\x12 \"") == "\"escape sequences: \\\"\\n\\0\\x12 \"");
+    PARSE(R"("string literal")", R"("string literal")");
+    PARSE(R"("escape sequences: \"\n\0\x12 ")", R"("escape sequences: \"\n\0\x12 ")");
     CHECK(parse("1,2,3") == "1, 2, 3");  // naked tuple
-    CHECK(parse("(1,2,\"str\")") == "(1, 2, \"str\")");  // bracketed tuple
+    PARSE(R"((1,2,"str"))", R"((1, 2, "str"))");  // bracketed tuple
     CHECK(parse("[1,2,3]") == "[1, 2, 3]");  // list
     CHECK(parse("[(1,2,3,4)]") == "[(1, 2, 3, 4)]");  // list with a tuple item
     CHECK(parse("[(1,2,3,4), 5]") == "[(1, 2, 3, 4), 5]");
@@ -142,20 +159,20 @@ TEST_CASE( "Values", "[script][parser]" )
 
 TEST_CASE( "Raw strings", "[script][parser]" )
 {
-    CHECK(parse("\"\"\"Hello\"\"\"") == "\"Hello\"");
-    CHECK(parse("\"\"\"\nHello\n\"\"\"") == "\"Hello\"");
-    CHECK(parse("\"\"\"\n  Hello\n  \"\"\"") == "\"Hello\"");
-    CHECK(parse("\"\"\"\n  Hello\n\"\"\"") == "\"  Hello\"");
-    CHECK(parse("\"\"\"\n  \\nHello\\0\n  \"\"\"") == "\"\\\\nHello\\\\0\"");
-    CHECK(parse("\"\"\"Hello\n\"\"\"") == "\"Hello\\n\"");
-    CHECK(parse("\"\"\"\n  Hello\"\"\"") == "\"\\n  Hello\"");
-    CHECK(parse("\"\"\"\n\nHello\n\n\"\"\"") == "\"\\nHello\\n\"");
-    CHECK(parse("\"\"\"\n  \\\"\"\"Hello\\\"\"\"\n  \"\"\"") == "\"\\\"\\\"\\\"Hello\\\"\\\"\\\"\"");
-    CHECK(parse("\"\"\"\n  \\\"\"\"\"Hello\\\"\"\"\"\n  \"\"\"") == "\"\\\"\\\"\\\"\\\"Hello\\\"\\\"\\\"\\\"\"");
-    CHECK(parse("\"\"\"\n  \\\"\"\"\n  \\\\\"\"\"\n  \\\\\\\"\"\"\n  \"\"\"")
-             == "\"\\\"\\\"\\\"\\n\\\\\\\"\\\"\\\"\\n\\\\\\\\\\\"\\\"\\\"\"");
+    PARSE(R"("""Hello""")", R"("Hello")");
+    PARSE("\"\"\"\nHello\n\"\"\"", R"("Hello")");
+    PARSE("\"\"\"\n  Hello\n  \"\"\"", R"("Hello")");
+    PARSE("\"\"\"\n  Hello\n\"\"\"", R"("  Hello")");
+    PARSE("\"\"\"\n  \\nHello\\0\n  \"\"\"", R"("\\nHello\\0")");
+    PARSE("\"\"\"Hello\n\"\"\"", R"("Hello\n")");
+    PARSE("\"\"\"\n  Hello\"\"\"", R"("\n  Hello")");
+    PARSE("\"\"\"\n\nHello\n\n\"\"\"", R"("\nHello\n")");
+    PARSE("\"\"\"\n  \\\"\"\"Hello\\\"\"\"\n  \"\"\"", R"("\"\"\"Hello\"\"\"")");
+    PARSE("\"\"\"\n  \\\"\"\"\"Hello\\\"\"\"\"\n  \"\"\"", R"("\"\"\"\"Hello\"\"\"\"")");
+    PARSE("\"\"\"\n  \\\"\"\"\n  \\\\\"\"\"\n  \\\\\\\"\"\"\n  \"\"\"",
+                R"("\"\"\"\n\\\"\"\"\n\\\\\"\"\"")");
     CHECK_THROWS_AS(parse("\"\"\"\\\"\"\""), ParseError);
-    CHECK(parse("\"\"\"\n\\\n\"\"\"") == "\"\\\\\"");
+    PARSE("\"\"\"\n\\\n\"\"\"", R"("\\")");
 }
 
 

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -132,12 +132,30 @@ TEST_CASE( "Values", "[script][parser]" )
     CHECK(parse("\"string literal\"") == "\"string literal\"");
     // Note: don't use raw string literal, it causes MSVC Error C2017 due to stringize operation in Catch2
     CHECK(parse("\"escape sequences: \\\"\\n\\0\\x12 \"") == "\"escape sequences: \\\"\\n\\0\\x12 \"");
-    CHECK(parse("$$ raw \n\r\t\" string $$") == "\" raw \\n\\r\\t\\\" string \"");
     CHECK(parse("1,2,3") == "1, 2, 3");  // naked tuple
     CHECK(parse("(1,2,\"str\")") == "(1, 2, \"str\")");  // bracketed tuple
     CHECK(parse("[1,2,3]") == "[1, 2, 3]");  // list
     CHECK(parse("[(1,2,3,4)]") == "[(1, 2, 3, 4)]");  // list with a tuple item
     CHECK(parse("[(1,2,3,4), 5]") == "[(1, 2, 3, 4), 5]");
+}
+
+
+TEST_CASE( "Raw strings", "[script][parser]" )
+{
+    CHECK(parse("\"\"\"Hello\"\"\"") == "\"Hello\"");
+    CHECK(parse("\"\"\"\nHello\n\"\"\"") == "\"Hello\"");
+    CHECK(parse("\"\"\"\n  Hello\n  \"\"\"") == "\"Hello\"");
+    CHECK(parse("\"\"\"\n  Hello\n\"\"\"") == "\"  Hello\"");
+    CHECK(parse("\"\"\"\n  \\nHello\\0\n  \"\"\"") == "\"\\\\nHello\\\\0\"");
+    CHECK(parse("\"\"\"Hello\n\"\"\"") == "\"Hello\\n\"");
+    CHECK(parse("\"\"\"\n  Hello\"\"\"") == "\"\\n  Hello\"");
+    CHECK(parse("\"\"\"\n\nHello\n\n\"\"\"") == "\"\\nHello\\n\"");
+    CHECK(parse("\"\"\"\n  \\\"\"\"Hello\\\"\"\"\n  \"\"\"") == "\"\\\"\\\"\\\"Hello\\\"\\\"\\\"\"");
+    CHECK(parse("\"\"\"\n  \\\"\"\"\"Hello\\\"\"\"\"\n  \"\"\"") == "\"\\\"\\\"\\\"\\\"Hello\\\"\\\"\\\"\\\"\"");
+    CHECK(parse("\"\"\"\n  \\\"\"\"\n  \\\\\"\"\"\n  \\\\\\\"\"\"\n  \"\"\"")
+             == "\"\\\"\\\"\\\"\\n\\\\\\\"\\\"\\\"\\n\\\\\\\\\\\"\\\"\\\"\"");
+    CHECK_THROWS_AS(parse("\"\"\"\\\"\"\""), ParseError);
+    CHECK(parse("\"\"\"\n\\\n\"\"\"") == "\"\\\\\"");
 }
 
 

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -163,6 +163,7 @@ TEST_CASE( "Raw strings", "[script][parser]" )
     PARSE("\"\"\"\nHello\n\"\"\"", R"("Hello")");
     PARSE("\"\"\"\n  Hello\n  \"\"\"", R"("Hello")");
     PARSE("\"\"\"\n  Hello\n\"\"\"", R"("  Hello")");
+    PARSE("\"\"\"\n    Hello\n  \"\"\"", R"("  Hello")");
     PARSE("\"\"\"\n  \\nHello\\0\n  \"\"\"", R"("\\nHello\\0")");
     PARSE("\"\"\"Hello\n\"\"\"", R"("Hello\n")");
     PARSE("\"\"\"\n  Hello\"\"\"", R"("\n  Hello")");


### PR DESCRIPTION
A raw string can be multi-line and can contain anything. Only the closing quotes need to be escaped when they appear in the content.

Rules:
* indentation and leading/trailing newlines are stripped, when both `"""` are on their own lines
* three or more quotes (`"""`) inside the literal are possible, by escaping them with a single `\`, i.e. every `\"""` becomes `"""`
* otherwise, `\` is not special
* any characters, including control characters like newline, are allowed inside the literal

```
x = """
    Can contain any \ or \n etc. 
    Nothing is special here, besides the closing quotes.
    Escape them like this: \"""
    This is also fine: \""""""""""""""""""""""
    And also this: \\\\\\\\\\\\\\\\\\\\\""" (only one backslash will be consumed)
    """
```
