### PR TITLE
[script] fix empty list literal, add cast [Char] <-> String

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -39,6 +39,6 @@ Checks: >
   -readability-container-size-empty,
   -readability-function-cognitive-complexity,
   -readability-else-after-return,
-  -readability-qualified-auto
-  -readability-isolate-declaration
+  -readability-qualified-auto,
+  -readability-isolate-declaration,
   -readability-identifier-length

--- a/share/script/std.fire
+++ b/share/script/std.fire
@@ -322,6 +322,8 @@ instance Cast Float64 Int32 { cast = { __cast 0xD8 } }
 instance Cast Float64 Int64 { cast = { __cast 0xD9 } }
 instance Cast Float64 Float32 { cast = { __cast 0xDC } }
 
+instance Cast [Char] String { cast = cast_to_string }
+instance Cast String [Char] { cast = cast_to_chars }
 
 class Bounded T {
     min : Void -> T

--- a/src/xci/core/string.cpp
+++ b/src/xci/core/string.cpp
@@ -198,6 +198,7 @@ std::string _to_utf8(std::basic_string_view<Elem> wstr)
 }
 
 std::string to_utf8(std::u16string_view wstr) { return _to_utf8(wstr); }
+std::string to_utf8(std::u32string_view wstr) { return _to_utf8(wstr); }
 
 #ifdef _WIN32
 std::string to_utf8(std::wstring_view wstr) { return _to_utf8(wstr); }

--- a/src/xci/core/string.h
+++ b/src/xci/core/string.h
@@ -127,6 +127,7 @@ std::u32string to_utf32(std::string_view utf8);
 
 // Convert UTF16/32 string to UTF8
 std::string to_utf8(std::u16string_view wstr);
+std::string to_utf8(std::u32string_view wstr);
 
 #ifdef _WIN32
 std::string to_utf8(std::wstring_view wstr);
@@ -139,7 +140,7 @@ const char8_t* utf8_next(const char8_t* utf8);
 
 template <StringIterator I>
 I utf8_next(I iter) {
-    const char8_t* a = reinterpret_cast<const char8_t*>(&*iter);
+    const auto* a = reinterpret_cast<const char8_t*>(&*iter);
     return iter + (utf8_next(a) - a);
 }
 
@@ -147,7 +148,7 @@ const char8_t* utf8_prev(const char8_t* utf8);
 
 template <StringReverseIterator RI>
 RI utf8_prev(RI riter) {
-    const char8_t* a = reinterpret_cast<const char8_t*>(&*riter);
+    const auto* a = reinterpret_cast<const char8_t*>(&*riter);
     return riter + (a - utf8_prev(a));
 }
 

--- a/src/xci/script/Builtin.h
+++ b/src/xci/script/Builtin.h
@@ -58,6 +58,7 @@ public:
 private:
     void add_intrinsics();
     void add_types();
+    void add_transform_functions();
     void add_io_functions();
     void add_introspections();
 };

--- a/src/xci/script/Error.h
+++ b/src/xci/script/Error.h
@@ -237,9 +237,9 @@ struct BranchTypeMismatch : public ScriptError {
 
 
 struct ListElemTypeMismatch : public ScriptError {
-    explicit ListElemTypeMismatch(const TypeInfo& exp, const TypeInfo& got)
+    explicit ListElemTypeMismatch(const TypeInfo& exp, const TypeInfo& got, const SourceLocation& loc)
             : ScriptError(fmt::format("list element type mismatch: got {} in list of {}",
-                                 got, exp)) {}
+                                 got, exp), loc) {}
 };
 
 

--- a/src/xci/script/Stack.h
+++ b/src/xci/script/Stack.h
@@ -56,7 +56,7 @@ public:
     void push(const TypedValue& v) { push(v.value()); }
 
     Value pull(const TypeInfo& type_info);
-    TypedValue pull_typed(const TypeInfo& type_info) { return TypedValue(pull(type_info), type_info); }
+    TypedValue pull_typed(const TypeInfo& type_info) { return {pull(type_info), type_info}; }
 
     template <ValueT T>
     T pull() {

--- a/src/xci/script/Value.cpp
+++ b/src/xci/script/Value.cpp
@@ -455,16 +455,21 @@ size_t ListV::length() const
 }
 
 
-Value ListV::value_at(size_t idx, const TypeInfo& elem_type) const
+const std::byte* ListV::raw_data() const
 {
-    assert(idx < length());
     const auto* data = slot.data() + sizeof(uint32_t);
     auto dd_size = bit_read<uint16_t>(data);
     data += dd_size;
+    return data;
+}
 
+
+Value ListV::value_at(size_t idx, const TypeInfo& elem_type) const
+{
+    assert(idx < length());
     auto elem = create_value(elem_type);
     const auto elem_size = elem_type.size();
-    elem.read(data + idx * elem_size);
+    elem.read(raw_data() + idx * elem_size);
     return elem;
 }
 

--- a/src/xci/script/Value.h
+++ b/src/xci/script/Value.h
@@ -112,6 +112,7 @@ struct ListV {
     explicit ListV(HeapSlot&& slot) : slot(move(slot)) {}
     bool operator ==(const ListV& rhs) const { return slot.slot() == rhs.slot.slot(); }  // same slot - cannot compare content without elem_type
     size_t length() const;
+    const std::byte* raw_data() const;
     Value value_at(size_t idx, const TypeInfo& elem_type) const;
 
     /// Slice the list. Indexes work similarly to Python.

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -406,6 +406,7 @@ TEST_CASE( "Variables", "[script][interpreter]" )
     CHECK_THROWS_AS(interpret_std("m = { m = m + 1 }"), MissingExplicitType);
     CHECK(interpret_std("m = { m = 1; m }; m") == "1");
     // "m = { m + 1 }" compiles fine, but infinitely recurses
+    CHECK_THROWS_AS(interpret_std("a:[Char] = [1,2,3]"), DefinitionTypeMismatch);
 }
 
 
@@ -704,7 +705,6 @@ TEST_CASE( "Casting", "[script][interpreter]" )
     CHECK(interpret_std("-42:Bool") == "true");  // '-' is part of Int literal, not an operator
     CHECK_THROWS_AS(interpret_std("- 42:Bool"), FunctionNotFound);  // now it's operator and that's an error: "neg Bool" not defined
     CHECK(interpret_std("(- 42):Bool") == "true");
-    //CHECK(interpret_std("['a', 'b', 'c']:String") == "abc");
     CHECK(interpret_std("(cast 42):Int64") == "42L");
     CHECK(interpret_std("a:Int64 = cast 42; a") == "42L");
     CHECK_THROWS_AS(interpret_std("cast 42"), FunctionConflict);  // must specify the result type
@@ -712,6 +712,11 @@ TEST_CASE( "Casting", "[script][interpreter]" )
     CHECK(interpret_std("min:Int") == "-2147483648");
     CHECK(interpret_std("max:UInt") == "4294967295U");
     CHECK(interpret_std("a:Int = min; a") == "-2147483648");
+    // [Char] <-> String
+    CHECK(interpret_std("cast_to_string ['a','b','c']") == "\"abc\"");
+    CHECK(interpret_std("['a','b','c']:String") == "\"abc\"");
+    CHECK(interpret_std("cast_to_chars \"abc\"") == "['a', 'b', 'c']");
+    CHECK(interpret_std("\"abc\":[Char]") == "['a', 'b', 'c']");
 }
 
 

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -385,6 +385,12 @@ TEST_CASE( "Literals", "[script][interpreter]" )
     CHECK_THROWS_AS(interpret("-9223372036854775809L"), ParseError);
     CHECK(interpret("18446744073709551615ul") == "18446744073709551615UL");
     CHECK_THROWS_AS(interpret("18446744073709551616UL"), ParseError);
+    // Lists
+    CHECK(interpret("[]") == "[]");  // no type -> [Void]
+    CHECK(interpret_std("[]:[Void]") == "[]");  // same
+    CHECK(interpret_std("[]:[Int]") == "[]");
+    CHECK(interpret_std("[].len") == "0U");
+    CHECK(interpret("[1,2,3]") == "[1, 2, 3]");
 }
 
 
@@ -755,9 +761,8 @@ TEST_CASE( "Slice", "[script][interpreter]" )
     CHECK(interpret_std("[1,2,3,4,5] .slice -1 -4 -1") == "[5, 4, 3]");
     CHECK(interpret_std("[1,2,3,4,5] .slice 5 1 1") == "[]");
     CHECK(interpret_std("[1,2,3,4,5] .slice 1 5 -1") == "[]");
-//    CHECK(interpret_std("[]:[Int] .slice 0 5 1") == "[]");
-//    CHECK(interpret_std("[]:[Int]") == "[]");
-//    CHECK(interpret_std("[]") == "[]");
+    CHECK(interpret_std("[] .slice 0 5 1") == "[]");
+    CHECK(interpret_std("[]:[Int] .slice 0 5 1") == "[]");
     CHECK(interpret_std("tail [1,2,3]") == "[2, 3]");
 }
 


### PR DESCRIPTION
Empty list literal `[]` can now be used in type-less context, it then becomes `[Void]`. That is a list of empty type (Void is 0 bytes).

Implemented casting between `[Char]` and `String` as builtins, so this now works:
```
"hello":[Char]
['x','y','z']:String
```
Note that `[Char]` is a list of 32bit chars, while `String` is represented in UTF-8.