### PR TITLE
[graphics] VariUnits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,10 +358,11 @@ if (XCI_INSTALL_DEVEL)
         FILE "xcikit-targets.cmake")
 
     set(XCI_INCLUDE_DIRS include)
+    set(XCI_PACKAGE_DIR "")
     include(CMakePackageConfigHelpers)
     configure_package_config_file(xcikit-config.cmake.in xcikit-config.cmake
         INSTALL_DESTINATION lib/cmake/xcikit
-        PATH_VARS XCI_INCLUDE_DIRS)
+        PATH_VARS XCI_PACKAGE_DIR XCI_INCLUDE_DIRS)
     write_basic_package_version_file(xcikit-config-version.cmake
         COMPATIBILITY SameMajorVersion)
     install(FILES

--- a/docs/coordinates.md
+++ b/docs/coordinates.md
@@ -13,9 +13,9 @@ Vulkan Coordinates
 ### Viewport coordinates
 
 Vulkan uses following viewport coordinates:
-- X axis goes from left to right
-- Y axis goes from top to bottom
-- Z axis goes from near to far
+- X-axis goes from left to right
+- Y-axis goes from top to bottom
+- Z-axis goes from near to far
 
 Note that Y axis is inverted in OpenGL, but that was fixed in Vulkan.
 It now goes the same direction as is usual in window coordinates.
@@ -97,16 +97,40 @@ a square, regardless of actual viewport size.
 XCI Coordinates
 ---------------
 
-For the purpose of rendering UI and text, we'll stay with the Vulkan
-coordinates, with one modification:
+There are three kinds of coordinates understood by xcikit:
 
-- One of the X/Y axis is expanded, so the visible coordinates go beyond -1/1.
-  This is the aspect ratio correction.
+- *Framebuffer pixels* - these are based on size of frame buffer
+  (the actual pixels being drawn on the screen)
+- *Screen pixels* - these are based on size of window as reported by OS
+  (the pixels with "normal" size)
+- *Viewport units* - partially normalized units that scale with the viewport size
+  (the size stays cca the same regardless of actual window size in pixels)
 
-We no longer need to flip Y coordinate as we did in OpenGL.
+The framebuffer pixels are used for low-level drawing. The projection matrix maps
+them directly to actual pixels. These are also reported back in e.g. mouse callback.
+
+Screen pixels should be preferred as an input, when the size of text/UI is not meant
+to scale with window size.
+The screen pixels might be the same as framebuffer pixels, or they might
+be bigger (this technique is used for high-DPI screens).
+
+Viewport units should be used for scaling text/UI with window size, if you want the same
+amount of content in small or big window (or device screen).
+
+See `demo_coords` in examples for live demonstration of all kinds of the
+coordinates.
+
+### Viewport units
+
+These units are based on uniform projection matrix - the default Vulkan coordinates.
+The only modification is aspect ratio correction:
+
+- One of the X/Y axes is expanded, so the visible coordinates go beyond -1/1.
+
+Note: We no longer need to flip Y coordinate as we did in OpenGL.
 Vulkan Y coordinate is well suited for drawing text or widgets, because
 we usually write from top to bottom.
- 
+
 The diagram shows that the square of (-1,-1) .. (1,1) is always completely
 covered by the view. Depending on actual ratio of width and height,
 it is expanded either horizontally or vertically.
@@ -124,21 +148,7 @@ it is expanded either horizontally or vertically.
 
 Same as with Vulkan coordinates, origin (0,0) is in the center of the screen.
 
-These coordinates are used for positioning text and widgets in the viewport.
-There is always the same amount of elements, disregarding the actual size
+These coordinates may be used for positioning text and widgets in the viewport.
+There is always the same amount of elements, regardless the actual size
 of window in pixels. In bigger window or on finer screen, the elements just
 get bigger and more detailed.
-
-These are called *scalable units* throughout xcikit.
-
-There are also two other kinds of units:
-- *Framebuffer pixels* - these are based on size of frame buffer
-  (the actual pixels being drawn on the screen)
-- *Screen pixels* - these are based on size of window as reported by OS
-  (the pixels with "normal" size)
-
-The screen pixels might be the same as framebuffer pixels, or they might
-be bigger (this technique is used for high-DPI screens).
-
-See `demo_coords` in examples for live demonstration of all kinds of the
-coordinates.

--- a/docs/coordinates.md
+++ b/docs/coordinates.md
@@ -68,7 +68,7 @@ compared to standard mathematical notation:
 To adjust the 2D view without touching Z coordinate, we can adjust
 some of the fields:
 
-- Change `ax`, `by` to scale the view, eg. set both to 0.5 to resize
+- Change `ax`, `by` to scale the view, e.g. set both to 0.5 to resize
   the view to (-2.0, 2.0) in both axes. Or, if we'd consider the model
   being rendered, this will scale it to half size.
 
@@ -123,28 +123,29 @@ coordinates.
 ### Viewport units
 
 These units are based on uniform projection matrix - the default Vulkan coordinates.
-The only modification is aspect ratio correction:
+The two modifications are scale and aspect ratio correction:
 
-- One of the X/Y axes is expanded, so the visible coordinates go beyond -1/1.
+- The basic unit is 1% of viewport size.
+- One of the X/Y axes is expanded, so the visible coordinates go beyond -50..50.
 
 Note: We no longer need to flip Y coordinate as we did in OpenGL.
 Vulkan Y coordinate is well suited for drawing text or widgets, because
 we usually write from top to bottom.
 
-The diagram shows that the square of (-1,-1) .. (1,1) is always completely
+The diagram shows that the square of (-50,-50) .. (50,50) is always completely
 covered by the view. Depending on actual ratio of width and height,
 it is expanded either horizontally or vertically.
 
-    horizontal+           vertical+
-    +---+-------+---+     +---------+
-    |   |       |   |     |    +    |
-    | + |  2x2  | + |     +---------+
-    |   |       |   |     |         |
-    +---+-------+---+     |   2x2   |
-                          |         |
-                          +---------+
-                          |    +    |
-                          +---------+
+    horizontal+             vertical+
+    +---+---------+---+     +---------+
+    |   |         |   |     |    +    |
+    | + | 100x100 | + |     +---------+
+    |   |         |   |     |         |
+    +---+---------+---+     | 100x100 |
+                            |         |
+                            +---------+
+                            |    +    |
+                            +---------+
 
 Same as with Vulkan coordinates, origin (0,0) is in the center of the screen.
 

--- a/examples/graphics/demo_coords.cpp
+++ b/examples/graphics/demo_coords.cpp
@@ -1,7 +1,7 @@
 // demo_coords.cpp created on 2018-03-18 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "common.h"
@@ -50,7 +50,6 @@ int main(int argc, const char* argv[])
     size_font.set_color(Color(70, 150, 255));
     Text mouse_pos(font, "Mouse position:    ");
     mouse_pos.set_color(Color(255, 150, 50));
-    mouse_pos.set_tab_stops({0.4_vp});
     std::string mouse_pos_str;
 
     Text help_text(font, "Units:     \tOrigin:\n"
@@ -63,7 +62,7 @@ int main(int argc, const char* argv[])
 
     bool scaling = true;
     ViewOrigin view_origin = ViewOrigin::Center;
-    VariUnits font_size = 0.05_vp;
+    VariUnits font_size = 2.5_vp;
 
     window.set_size_callback([&](View& view) {
         auto vs = view.viewport_size();
@@ -87,12 +86,16 @@ int main(int argc, const char* argv[])
             coords_br.set_fixed_string(format("({}, {})", c.x + 0.5f * vs.x, c.y + 0.5f * vs.y));
             coords_tr.set_fixed_string(format("({}, {})", c.x + 0.5f * vs.x, c.y - 0.5f * vs.y));
             coords_bl.set_fixed_string(format("({}, {})", c.x - 0.5f * vs.x, c.y + 0.5f * vs.y));
+            mouse_pos.set_tab_stops({20_vp});
+            help_text.set_tab_stops({20_vp});
         } else {
             auto c = view.screen_center();
             coords_tl.set_fixed_string(format("({}, {})", c.x - 0.5f * ps.x, c.y - 0.5f * ps.y));
             coords_br.set_fixed_string(format("({}, {})", c.x + 0.5f * ps.x, c.y + 0.5f * ps.y));
             coords_tr.set_fixed_string(format("({}, {})", c.x + 0.5f * ps.x, c.y - 0.5f * ps.y));
             coords_bl.set_fixed_string(format("({}, {})", c.x - 0.5f * ps.x, c.y + 0.5f * ps.y));
+            mouse_pos.set_tab_stops({120_px});
+            help_text.set_tab_stops({120_px});
         }
         coords_center.resize(view);
         coords_tl.resize(view);
@@ -123,9 +126,9 @@ int main(int argc, const char* argv[])
 
         unit_square.clear();
         if (view_origin == ViewOrigin::Center)
-            unit_square.add_rectangle(view.vp_to_fb({-1, -1, 2, 2}), view.px_to_fb(1_px));
+            unit_square.add_rectangle(view.vp_to_fb({-50, -50, 100, 100}), view.px_to_fb(1_px));
         else
-            unit_square.add_rectangle(view.vp_to_fb({0, 0, 2, 2}), view.px_to_fb(1_px));
+            unit_square.add_rectangle(view.vp_to_fb({0, 0, 100, 100}), view.px_to_fb(1_px));
         unit_square.update();
     });
 
@@ -143,27 +146,27 @@ int main(int argc, const char* argv[])
             coords_br.draw(view, {vc.x + 0.30f * vs.x, vc.y + 0.45f * vs.y});
             coords_tr.draw(view, {vc.x + 0.30f * vs.x, vc.y - 0.45f * vs.y});
             coords_bl.draw(view, {vc.x - 0.45f * vs.x, vc.y + 0.45f * vs.y});
-            size_scal.draw(view, {vc.x - 0.4f, vc.y - 0.5f});
-            size_screen.draw(view, {vc.x - 0.4f, vc.y - 0.4f});
-            size_frame.draw(view, {vc.x - 0.4f, vc.y - 0.3f});
-            size_font.draw(view, {vc.x - 0.4f, vc.y - 0.2f});
-            mouse_pos.draw(view, {vc.x - 0.4f, vc.y + 0.2f});
-            help_text.draw(view, {vc.x - 0.4f, vc.y + 0.5f});
+            size_scal.draw(view, {vc.x - 20_vp, vc.y - 25_vp});
+            size_screen.draw(view, {vc.x - 20_vp, vc.y - 20_vp});
+            size_frame.draw(view, {vc.x - 20_vp, vc.y - 15_vp});
+            size_font.draw(view, {vc.x - 20_vp, vc.y - 10_vp});
+            mouse_pos.draw(view, {vc.x - 20_vp, vc.y + 10_vp});
+            help_text.draw(view, {vc.x - 20_vp, vc.y + 25_vp});
         } else {
             auto size = view.screen_size();
             auto sc = view.screen_center();
             auto tl = sc - 0.5 * size;
             auto br = sc + 0.5 * size;
-            coords_tl.draw(view, {tl.x + 30, tl.y + 30});
-            coords_br.draw(view, {br.x - 150, br.y - 30});
-            coords_tr.draw(view, {br.x - 150, tl.y + 30});
-            coords_bl.draw(view, {tl.x + 30, br.y - 30});
-            size_scal.draw(view, {sc.x - 120, sc.y - 150});
-            size_screen.draw(view, {sc.x - 120, sc.y - 120});
-            size_frame.draw(view, {sc.x - 120, sc.y - 90});
-            size_font.draw(view, {sc.x - 120, sc.y - 60});
-            mouse_pos.draw(view, {sc.x - 120, sc.y + 60});
-            help_text.draw(view, {sc.x - 120, sc.y + 120});
+            coords_tl.draw(view, {tl.x + 30_px, tl.y + 30_px});
+            coords_br.draw(view, {br.x - 150_px, br.y - 30_px});
+            coords_tr.draw(view, {br.x - 150_px, tl.y + 30_px});
+            coords_bl.draw(view, {tl.x + 30_px, br.y - 30_px});
+            size_scal.draw(view, {sc.x - 120_px, sc.y - 150_px});
+            size_screen.draw(view, {sc.x - 120_px, sc.y - 120_px});
+            size_frame.draw(view, {sc.x - 120_px, sc.y - 90_px});
+            size_font.draw(view, {sc.x - 120_px, sc.y - 60_px});
+            mouse_pos.draw(view, {sc.x - 120_px, sc.y + 60_px});
+            help_text.draw(view, {sc.x - 120_px, sc.y + 120_px});
         }
     });
 
@@ -179,7 +182,7 @@ int main(int argc, const char* argv[])
                 break;
             case Key::S:
                 scaling = true;
-                font_size = 0.05_vp;
+                font_size = 2.5_vp;
                 window.size_callback()(view);
                 view.refresh();
                 break;
@@ -191,13 +194,13 @@ int main(int argc, const char* argv[])
                 break;
             case Key::C:
                 view_origin = ViewOrigin::Center;
-                window.set_view_mode(view_origin);
+                window.set_view_origin(view_origin);
                 window.size_callback()(view);
                 view.refresh();
                 break;
             case Key::T:
                 view_origin = ViewOrigin::TopLeft;
-                window.set_view_mode(view_origin);
+                window.set_view_origin(view_origin);
                 window.size_callback()(view);
                 view.refresh();
                 break;

--- a/examples/graphics/demo_coords.cpp
+++ b/examples/graphics/demo_coords.cpp
@@ -40,8 +40,8 @@ int main(int argc, const char* argv[])
     Text coords_br(font, "(-, -)");
     Text coords_tr(font, "(-, -)");
     Text coords_bl(font, "(-, -)");
-    Text size_scal(font, "Viewport size:         ");
-    size_scal.set_color(Color(130, 120, 255));
+    Text size_viewport(font, "Viewport size:         ");
+    size_viewport.set_color(Color(130, 120, 255));
     Text size_screen(font, "Screen size:       ");
     size_screen.set_color(Color(110, 130, 255));
     Text size_frame(font, "Framebuffer size:  ");
@@ -52,9 +52,9 @@ int main(int argc, const char* argv[])
     mouse_pos.set_color(Color(255, 150, 50));
     std::string mouse_pos_str;
 
-    Text help_text(font, "Units:     \tOrigin:\n"
-                         "[s] scaling\t[c] center\n"
-                         "[f] fixed  \t[t] top-left\n");
+    Text help_text(font, "Units:     \tOrigin:     \tScale:\n"
+                         "[s] scaling\t[c] center  \t[+] bigger\n"
+                         "[f] fixed  \t[t] top-left\t[-] smaller\n");
     help_text.set_color(Color(200, 100, 50));
 
     Shape unit_square(renderer, Color::Transparent(),
@@ -73,7 +73,7 @@ int main(int argc, const char* argv[])
         coords_br.set_font_size(font_size);
         coords_tr.set_font_size(font_size);
         coords_bl.set_font_size(font_size);
-        size_scal.set_font_size(font_size);
+        size_viewport.set_font_size(font_size);
         size_screen.set_font_size(font_size);
         size_frame.set_font_size(font_size);
         size_font.set_font_size(font_size);
@@ -87,7 +87,7 @@ int main(int argc, const char* argv[])
             coords_tr.set_fixed_string(format("({}, {})", c.x + 0.5f * vs.x, c.y - 0.5f * vs.y));
             coords_bl.set_fixed_string(format("({}, {})", c.x - 0.5f * vs.x, c.y + 0.5f * vs.y));
             mouse_pos.set_tab_stops({20_vp});
-            help_text.set_tab_stops({20_vp});
+            help_text.set_tab_stops({20_vp, 20_vp});
         } else {
             auto c = view.screen_center();
             coords_tl.set_fixed_string(format("({}, {})", c.x - 0.5f * ps.x, c.y - 0.5f * ps.y));
@@ -95,7 +95,7 @@ int main(int argc, const char* argv[])
             coords_tr.set_fixed_string(format("({}, {})", c.x + 0.5f * ps.x, c.y - 0.5f * ps.y));
             coords_bl.set_fixed_string(format("({}, {})", c.x - 0.5f * ps.x, c.y + 0.5f * ps.y));
             mouse_pos.set_tab_stops({120_px});
-            help_text.set_tab_stops({120_px});
+            help_text.set_tab_stops({120_px, 120_px});
         }
         coords_center.resize(view);
         coords_tl.resize(view);
@@ -104,19 +104,23 @@ int main(int argc, const char* argv[])
         coords_bl.resize(view);
         help_text.resize(view);
 
-        size_scal.set_fixed_string("Viewport size:     " +
-                                   format("{} x {}", vs.x, vs.y) +
-                                   "  (1 x 1)");
-        size_scal.resize(view);
+        float scale = view.viewport_scale();
+        size_viewport.set_fixed_string(
+                "Viewport size:     " +
+                format("{} x {}", vs.x, vs.y) +
+                "  (" + format("{} x {}", scale, scale) + ")");
+        size_viewport.resize(view);
 
-        size_screen.set_fixed_string("Screen size:       " +
-                                     format("{} x {}", ps.x, ps.y) +
-                                     "  (" + format("{} x {}", ps.x.value/vs.x.value, ps.y.value/vs.y.value) + ")");
+        size_screen.set_fixed_string(
+                "Screen size:       " +
+                format("{} x {}", ps.x, ps.y) +
+                "  (" + format("{} x {}", ps.x * scale / vs.x.value, ps.y * scale / vs.y.value) + ")");
         size_screen.resize(view);
 
-        size_frame.set_fixed_string("Framebuffer size:  " +
-                                    format("{} x {}", fs.x, fs.y) +
-                                    "  (" + format("{} x {}", fs.x.value/vs.x.value, fs.y.value/vs.y.value) + ")");
+        size_frame.set_fixed_string(
+                "Framebuffer size:  " +
+                format("{} x {}", fs.x, fs.y) +
+                "  (" + format("{} x {}", fs.x * scale / vs.x.value, fs.y * scale / vs.y.value) + ")");
         size_frame.resize(view);
 
         size_font.set_fixed_string(format("Font size:         {}", font.size()));
@@ -146,7 +150,7 @@ int main(int argc, const char* argv[])
             coords_br.draw(view, {vc.x + 0.30f * vs.x, vc.y + 0.45f * vs.y});
             coords_tr.draw(view, {vc.x + 0.30f * vs.x, vc.y - 0.45f * vs.y});
             coords_bl.draw(view, {vc.x - 0.45f * vs.x, vc.y + 0.45f * vs.y});
-            size_scal.draw(view, {vc.x - 20_vp, vc.y - 25_vp});
+            size_viewport.draw(view, {vc.x - 20_vp, vc.y - 25_vp});
             size_screen.draw(view, {vc.x - 20_vp, vc.y - 20_vp});
             size_frame.draw(view, {vc.x - 20_vp, vc.y - 15_vp});
             size_font.draw(view, {vc.x - 20_vp, vc.y - 10_vp});
@@ -161,7 +165,7 @@ int main(int argc, const char* argv[])
             coords_br.draw(view, {br.x - 150_px, br.y - 30_px});
             coords_tr.draw(view, {br.x - 150_px, tl.y + 30_px});
             coords_bl.draw(view, {tl.x + 30_px, br.y - 30_px});
-            size_scal.draw(view, {sc.x - 120_px, sc.y - 150_px});
+            size_viewport.draw(view, {sc.x - 120_px, sc.y - 150_px});
             size_screen.draw(view, {sc.x - 120_px, sc.y - 120_px});
             size_frame.draw(view, {sc.x - 120_px, sc.y - 90_px});
             size_font.draw(view, {sc.x - 120_px, sc.y - 60_px});
@@ -173,6 +177,7 @@ int main(int argc, const char* argv[])
     window.set_key_callback([&](View& view, KeyEvent ev){
         if (ev.action != Action::Press)
             return;
+        bool refresh = false;
         switch (ev.key) {
             case Key::Escape:
                 window.close();
@@ -183,29 +188,47 @@ int main(int argc, const char* argv[])
             case Key::S:
                 scaling = true;
                 font_size = 2.5_vp;
-                window.size_callback()(view);
-                view.refresh();
+                refresh = true;
                 break;
             case Key::F:
                 scaling = false;
                 font_size = 15_px;
-                window.size_callback()(view);
-                view.refresh();
+                refresh = true;
                 break;
             case Key::C:
                 view_origin = ViewOrigin::Center;
                 window.set_view_origin(view_origin);
-                window.size_callback()(view);
-                view.refresh();
+                refresh = true;
                 break;
             case Key::T:
                 view_origin = ViewOrigin::TopLeft;
                 window.set_view_origin(view_origin);
-                window.size_callback()(view);
-                view.refresh();
+                refresh = true;
                 break;
+            case Key::Equal:
+            case Key::KeypadAdd: {
+                float scale = view.viewport_scale();
+                if (scale < 200)
+                    scale += 5;
+                view.set_viewport_scale(scale);
+                refresh = true;
+                break;
+            }
+            case Key::Minus:
+            case Key::KeypadSubtract: {
+                float scale = view.viewport_scale();
+                if (scale > 50)
+                    scale -= 5;
+                view.set_viewport_scale(scale);
+                refresh = true;
+                break;
+            }
             default:
                 break;
+        }
+        if (refresh) {
+            window.size_callback()(view);
+            view.refresh();
         }
     });
 

--- a/examples/graphics/demo_coords.cpp
+++ b/examples/graphics/demo_coords.cpp
@@ -114,9 +114,9 @@ int main(int argc, const char* argv[])
 
         unit_square.clear();
         if (view_origin == ViewOrigin::Center)
-            unit_square.add_rectangle({-1, -1, 2, 2}, view.size_to_viewport(1_sc));
+            unit_square.add_rectangle({-1, -1, 2, 2}, view.size_to_viewport(1_px));
         else
-            unit_square.add_rectangle({0, 0, 2, 2}, view.size_to_viewport(1_sc));
+            unit_square.add_rectangle({0, 0, 2, 2}, view.size_to_viewport(1_px));
         unit_square.update();
     });
 

--- a/examples/graphics/demo_fps.cpp
+++ b/examples/graphics/demo_fps.cpp
@@ -1,7 +1,7 @@
 // demo_fps.cpp created on 2018-04-14 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "common.h"
@@ -40,7 +40,7 @@ int main(int argc, const char* argv[])
     rts_px.set_antialiasing(2);
 
     FpsDisplay fps_display(theme);
-    fps_display.set_position({-1.2_vp, -0.7_vp});
+    fps_display.set_position({-60_vp, -35_vp});
     Text help_text(font, "[p] periodic\t[i] immediate\n"
                          "[d] on demand\t[f] fifo\n"
                          "[e] on event\t[m] mailbox\n");
@@ -50,19 +50,17 @@ int main(int argc, const char* argv[])
 
     window.set_size_callback([&](View& view) {
         // Viewport units - the border scales with viewport size
-        rts.clear();
-        rts.add_ellipse(view.vp_to_fb({-1.f, -0.6f, 2.f, 1.2f}), view.vp_to_fb(0.05f));
-        rts.add_ellipse(view.vp_to_fb({-0.6f, -0.8f, 1.2f, 1.6f}), view.vp_to_fb(0.02f));
-        rts.update();
+        ShapeBuilder(view, rts)
+            .add_ellipse({-50_vp, -30_vp, 100_vp, 60_vp}, 2.5_vp)
+            .add_ellipse({-30_vp, -40_vp, 60_vp, 80_vp}, 1_vp);
 
         // Constant border width, in screen pixels
-        rts_px.clear();
-        rts_px.add_ellipse(view.vp_to_fb({0.0f, 0.0f, 0.5f, 0.5f}), view.px_to_fb(1_px));
-        rts_px.add_ellipse(view.vp_to_fb({0.1f, 0.1f, 0.5f, 0.5f}), view.px_to_fb(2_px));
-        rts_px.add_ellipse(view.vp_to_fb({0.2f, 0.2f, 0.5f, 0.5f}), view.px_to_fb(3_px));
-        rts_px.add_ellipse(view.vp_to_fb({0.3f, 0.3f, 0.5f, 0.5f}), view.px_to_fb(4_px));
-        rts_px.add_ellipse(view.vp_to_fb({0.4f, 0.4f, 0.5f, 0.5f}), view.px_to_fb(5_px));
-        rts_px.update();
+        ShapeBuilder(view, rts_px)
+            .add_ellipse({ 0_vp,  0_vp, 25_vp, 25_vp}, view.px_to_fb(1_px))
+            .add_ellipse({ 5_vp,  5_vp, 25_vp, 25_vp}, view.px_to_fb(2_px))
+            .add_ellipse({10_vp, 10_vp, 25_vp, 25_vp}, view.px_to_fb(3_px))
+            .add_ellipse({15_vp, 15_vp, 25_vp, 25_vp}, view.px_to_fb(4_px))
+            .add_ellipse({20_vp, 20_vp, 25_vp, 25_vp}, view.px_to_fb(5_px));
 
         fps_display.resize(view);
         help_text.resize(view);
@@ -81,11 +79,11 @@ int main(int argc, const char* argv[])
 
     window.set_draw_callback([&](View& view) {
         rts.draw(view, {0_vp, 0_vp});
-        rts_px.draw(view, {-0.45_vp, -0.45_vp});
+        rts_px.draw(view, {-22.5_vp, -22.5_vp});
 
-        help_text.draw(view, {-1.2_vp, -0.9_vp});
+        help_text.draw(view, {-60_vp, -45_vp});
         fps_display.draw(view);
-        mouse_pos.draw(view, {-1.2_vp, 0.9_vp});
+        mouse_pos.draw(view, {-60_vp, 45_vp});
     });
 
     window.set_key_callback([&](View& view, KeyEvent ev){

--- a/examples/graphics/demo_fps.cpp
+++ b/examples/graphics/demo_fps.cpp
@@ -55,11 +55,11 @@ int main(int argc, const char* argv[])
     window.set_size_callback([&](View& view) {
         rts.update();
         rts_px.clear();
-        rts_px.add_ellipse({0.0f, 0.0f, 0.5f, 0.5f}, view.size_to_viewport(1_sc));
-        rts_px.add_ellipse({0.1f, 0.1f, 0.5f, 0.5f}, view.size_to_viewport(2_sc));
-        rts_px.add_ellipse({0.2f, 0.2f, 0.5f, 0.5f}, view.size_to_viewport(3_sc));
-        rts_px.add_ellipse({0.3f, 0.3f, 0.5f, 0.5f}, view.size_to_viewport(4_sc));
-        rts_px.add_ellipse({0.4f, 0.4f, 0.5f, 0.5f}, view.size_to_viewport(5_sc));
+        rts_px.add_ellipse({0.0f, 0.0f, 0.5f, 0.5f}, view.size_to_viewport(1_px));
+        rts_px.add_ellipse({0.1f, 0.1f, 0.5f, 0.5f}, view.size_to_viewport(2_px));
+        rts_px.add_ellipse({0.2f, 0.2f, 0.5f, 0.5f}, view.size_to_viewport(3_px));
+        rts_px.add_ellipse({0.3f, 0.3f, 0.5f, 0.5f}, view.size_to_viewport(4_px));
+        rts_px.add_ellipse({0.4f, 0.4f, 0.5f, 0.5f}, view.size_to_viewport(5_px));
         rts_px.update();
         fps_display.resize(view);
         help_text.resize(view);

--- a/examples/graphics/demo_fps.cpp
+++ b/examples/graphics/demo_fps.cpp
@@ -33,18 +33,14 @@ int main(int argc, const char* argv[])
         return EXIT_FAILURE;
     auto& font = theme.font();
 
-    // normally, the border scales with viewport size
     Shape rts(renderer, Color(0, 0, 40, 128), Color(180, 180, 0));
     rts.set_antialiasing(2);
-    rts.add_ellipse({-1.f, -0.6f, 2.f, 1.2f}, 0.05f);
-    rts.add_ellipse({-0.6f, -0.8f, 1.2f, 1.6f}, 0.02f);
 
-    // using View::screen_ratio, we can set constant border width, in screen pixels
     Shape rts_px(renderer, Color(40, 40, 0, 128), Color(255, 255, 0));
     rts_px.set_antialiasing(2);
 
     FpsDisplay fps_display(theme);
-    fps_display.set_position({-1.2f, -0.7f});
+    fps_display.set_position({-1.2_vp, -0.7_vp});
     Text help_text(font, "[p] periodic\t[i] immediate\n"
                          "[d] on demand\t[f] fifo\n"
                          "[e] on event\t[m] mailbox\n");
@@ -53,14 +49,21 @@ int main(int argc, const char* argv[])
     std::string mouse_pos_str;
 
     window.set_size_callback([&](View& view) {
+        // Viewport units - the border scales with viewport size
+        rts.clear();
+        rts.add_ellipse(view.vp_to_fb({-1.f, -0.6f, 2.f, 1.2f}), view.vp_to_fb(0.05f));
+        rts.add_ellipse(view.vp_to_fb({-0.6f, -0.8f, 1.2f, 1.6f}), view.vp_to_fb(0.02f));
         rts.update();
+
+        // Constant border width, in screen pixels
         rts_px.clear();
-        rts_px.add_ellipse({0.0f, 0.0f, 0.5f, 0.5f}, view.size_to_viewport(1_px));
-        rts_px.add_ellipse({0.1f, 0.1f, 0.5f, 0.5f}, view.size_to_viewport(2_px));
-        rts_px.add_ellipse({0.2f, 0.2f, 0.5f, 0.5f}, view.size_to_viewport(3_px));
-        rts_px.add_ellipse({0.3f, 0.3f, 0.5f, 0.5f}, view.size_to_viewport(4_px));
-        rts_px.add_ellipse({0.4f, 0.4f, 0.5f, 0.5f}, view.size_to_viewport(5_px));
+        rts_px.add_ellipse(view.vp_to_fb({0.0f, 0.0f, 0.5f, 0.5f}), view.px_to_fb(1_px));
+        rts_px.add_ellipse(view.vp_to_fb({0.1f, 0.1f, 0.5f, 0.5f}), view.px_to_fb(2_px));
+        rts_px.add_ellipse(view.vp_to_fb({0.2f, 0.2f, 0.5f, 0.5f}), view.px_to_fb(3_px));
+        rts_px.add_ellipse(view.vp_to_fb({0.3f, 0.3f, 0.5f, 0.5f}), view.px_to_fb(4_px));
+        rts_px.add_ellipse(view.vp_to_fb({0.4f, 0.4f, 0.5f, 0.5f}), view.px_to_fb(5_px));
         rts_px.update();
+
         fps_display.resize(view);
         help_text.resize(view);
         mouse_pos.resize(view);
@@ -77,12 +80,12 @@ int main(int argc, const char* argv[])
     });
 
     window.set_draw_callback([&](View& view) {
-        rts.draw(view, {0, 0});
-        rts_px.draw(view, {-0.45f, -0.45f});
+        rts.draw(view, {0_vp, 0_vp});
+        rts_px.draw(view, {-0.45_vp, -0.45_vp});
 
-        help_text.draw(view, {-1.2f, -0.9f});
+        help_text.draw(view, {-1.2_vp, -0.9_vp});
         fps_display.draw(view);
-        mouse_pos.draw(view, {-1.2f, 0.9f});
+        mouse_pos.draw(view, {-1.2_vp, 0.9_vp});
     });
 
     window.set_key_callback([&](View& view, KeyEvent ev){

--- a/examples/graphics/demo_fps.cpp
+++ b/examples/graphics/demo_fps.cpp
@@ -56,11 +56,11 @@ int main(int argc, const char* argv[])
 
         // Constant border width, in screen pixels
         ShapeBuilder(view, rts_px)
-            .add_ellipse({ 0_vp,  0_vp, 25_vp, 25_vp}, view.px_to_fb(1_px))
-            .add_ellipse({ 5_vp,  5_vp, 25_vp, 25_vp}, view.px_to_fb(2_px))
-            .add_ellipse({10_vp, 10_vp, 25_vp, 25_vp}, view.px_to_fb(3_px))
-            .add_ellipse({15_vp, 15_vp, 25_vp, 25_vp}, view.px_to_fb(4_px))
-            .add_ellipse({20_vp, 20_vp, 25_vp, 25_vp}, view.px_to_fb(5_px));
+            .add_ellipse({ 0_vp,  0_vp, 25_vp, 25_vp}, 1_px)
+            .add_ellipse({ 5_vp,  5_vp, 25_vp, 25_vp}, 2_px)
+            .add_ellipse({10_vp, 10_vp, 25_vp, 25_vp}, 3_px)
+            .add_ellipse({15_vp, 15_vp, 25_vp, 25_vp}, 4_px)
+            .add_ellipse({20_vp, 20_vp, 25_vp, 25_vp}, 5_px);
 
         fps_display.resize(view);
         help_text.resize(view);

--- a/examples/graphics/demo_shapes.cpp
+++ b/examples/graphics/demo_shapes.cpp
@@ -134,11 +134,11 @@ int main(int argc, const char* argv[])
         add_shape_fn(shapes[1], {-0.6f, -0.8f, 1.2f, 1.6f}, 0.02f);
 
         // Constant border width, in screen pixels
-        add_shape_fn(shapes[2], {0.0f, 0.0f, 0.5f, 0.5f}, view.size_to_viewport(1_sc));
-        add_shape_fn(shapes[3], {0.1f, 0.1f, 0.5f, 0.5f}, view.size_to_viewport(2_sc));
-        add_shape_fn(shapes[4], {0.2f, 0.2f, 0.5f, 0.5f}, view.size_to_viewport(3_sc));
-        add_shape_fn(shapes[5], {0.3f, 0.3f, 0.5f, 0.5f}, view.size_to_viewport(4_sc));
-        add_shape_fn(shapes[6], {0.4f, 0.4f, 0.5f, 0.5f}, view.size_to_viewport(5_sc));
+        add_shape_fn(shapes[2], {0.0f, 0.0f, 0.5f, 0.5f}, view.size_to_viewport(1_px));
+        add_shape_fn(shapes[3], {0.1f, 0.1f, 0.5f, 0.5f}, view.size_to_viewport(2_px));
+        add_shape_fn(shapes[4], {0.2f, 0.2f, 0.5f, 0.5f}, view.size_to_viewport(3_px));
+        add_shape_fn(shapes[5], {0.3f, 0.3f, 0.5f, 0.5f}, view.size_to_viewport(4_px));
+        add_shape_fn(shapes[6], {0.4f, 0.4f, 0.5f, 0.5f}, view.size_to_viewport(5_px));
 
         for (Shape& shape : shapes)
             shape.update();

--- a/examples/graphics/demo_shapes.cpp
+++ b/examples/graphics/demo_shapes.cpp
@@ -1,7 +1,7 @@
 // demo_rectangles.cpp created on 2018-03-19 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "common.h"
@@ -70,15 +70,15 @@ int main(int argc, const char* argv[])
         }
 
         // Border scaled with viewport size
-        add_shape_fn(shapes[0], view.vp_to_fb({-1.0f, -0.6f, 2.0f, 1.2f}), view.vp_to_fb(0.05f));
-        add_shape_fn(shapes[1], view.vp_to_fb({-0.6f, -0.8f, 1.2f, 1.6f}), view.vp_to_fb(0.02f));
+        add_shape_fn(shapes[0], view.vp_to_fb({-50_vp, -30_vp, 100_vp, 60_vp}), view.vp_to_fb(2.5_vp));
+        add_shape_fn(shapes[1], view.vp_to_fb({-30_vp, -40_vp, 60_vp, 80_vp}), view.vp_to_fb(1_vp));
 
         // Constant border width, in screen pixels
-        add_shape_fn(shapes[2], view.vp_to_fb({0.0f, 0.0f, 0.5f, 0.5f}), view.px_to_fb(1_px));
-        add_shape_fn(shapes[3], view.vp_to_fb({0.1f, 0.1f, 0.5f, 0.5f}), view.px_to_fb(2_px));
-        add_shape_fn(shapes[4], view.vp_to_fb({0.2f, 0.2f, 0.5f, 0.5f}), view.px_to_fb(3_px));
-        add_shape_fn(shapes[5], view.vp_to_fb({0.3f, 0.3f, 0.5f, 0.5f}), view.px_to_fb(4_px));
-        add_shape_fn(shapes[6], view.vp_to_fb({0.4f, 0.4f, 0.5f, 0.5f}), view.px_to_fb(5_px));
+        add_shape_fn(shapes[2], view.vp_to_fb({ 0_vp,  0_vp, 25_vp, 25_vp}), view.px_to_fb(1_px));
+        add_shape_fn(shapes[3], view.vp_to_fb({ 5_vp,  5_vp, 25_vp, 25_vp}), view.px_to_fb(2_px));
+        add_shape_fn(shapes[4], view.vp_to_fb({10_vp, 10_vp, 25_vp, 25_vp}), view.px_to_fb(3_px));
+        add_shape_fn(shapes[5], view.vp_to_fb({15_vp, 15_vp, 25_vp, 25_vp}), view.px_to_fb(4_px));
+        add_shape_fn(shapes[6], view.vp_to_fb({20_vp, 20_vp, 25_vp, 25_vp}), view.px_to_fb(5_px));
 
         for (Shape& shape : shapes)
             shape.update();
@@ -102,7 +102,7 @@ int main(int argc, const char* argv[])
                 break;
             case Key::O:
                 add_shape_fn = [&](Shape& shape, const FramebufferRect& rect, FramebufferPixels th) {
-                    shape.add_rounded_rectangle(rect, view.vp_to_fb(0.05_vp), th);
+                    shape.add_rounded_rectangle(rect, view.vp_to_fb(2.5_vp), th);
                 };
                 break;
             case Key::E:
@@ -148,14 +148,14 @@ int main(int argc, const char* argv[])
 
     window.set_draw_callback([&](View& view) {
         auto vs = view.viewport_size();
-        shapes_help.draw(view, {-vs.x / 2 + 0.1_vp, -vs.y / 2 + 0.1_vp});
-        option_help.draw(view, {vs.x / 2 - 0.5_vp, -vs.y / 2 + 0.1_vp});
+        shapes_help.draw(view, {-vs.x / 2 + 5_vp, -vs.y / 2 + 5_vp});
+        option_help.draw(view, {vs.x / 2 - 25_vp, -vs.y / 2 + 5_vp});
 
         shapes[0].draw(view, {0_vp, 0_vp});
         shapes[1].draw(view, {0_vp, 0_vp});
 
         for (size_t i = 2; i <= 6; i++)
-            shapes[i].draw(view, {-0.45_vp, -0.45_vp});
+            shapes[i].draw(view, {-22.5_vp, -22.5_vp});
     });
 
     window.set_refresh_mode(RefreshMode::OnDemand);

--- a/examples/graphics/demo_shapes.cpp
+++ b/examples/graphics/demo_shapes.cpp
@@ -44,8 +44,8 @@ int main(int argc, const char* argv[])
     int antialiasing = 0;
     int softness = 0;
 
-    std::function<void(Shape&, const ViewportRect&, ViewportUnits)>
-    add_shape_fn = [](Shape& shape, const ViewportRect& rect, ViewportUnits th) {
+    std::function add_shape_fn = [](Shape& shape, const FramebufferRect& rect, FramebufferPixels th)
+    {
         shape.add_rectangle(rect, th);
     };
 
@@ -61,6 +61,29 @@ int main(int argc, const char* argv[])
         shape.set_softness(softness);
     };
 
+    auto recreate_shapes = [&](View& view) {
+        view.finish_draw();
+
+        for (Shape& shape : shapes) {
+            shape.clear();
+            set_shape_attr(shape);
+        }
+
+        // Border scaled with viewport size
+        add_shape_fn(shapes[0], view.vp_to_fb({-1.0f, -0.6f, 2.0f, 1.2f}), view.vp_to_fb(0.05f));
+        add_shape_fn(shapes[1], view.vp_to_fb({-0.6f, -0.8f, 1.2f, 1.6f}), view.vp_to_fb(0.02f));
+
+        // Constant border width, in screen pixels
+        add_shape_fn(shapes[2], view.vp_to_fb({0.0f, 0.0f, 0.5f, 0.5f}), view.px_to_fb(1_px));
+        add_shape_fn(shapes[3], view.vp_to_fb({0.1f, 0.1f, 0.5f, 0.5f}), view.px_to_fb(2_px));
+        add_shape_fn(shapes[4], view.vp_to_fb({0.2f, 0.2f, 0.5f, 0.5f}), view.px_to_fb(3_px));
+        add_shape_fn(shapes[5], view.vp_to_fb({0.3f, 0.3f, 0.5f, 0.5f}), view.px_to_fb(4_px));
+        add_shape_fn(shapes[6], view.vp_to_fb({0.4f, 0.4f, 0.5f, 0.5f}), view.px_to_fb(5_px));
+
+        for (Shape& shape : shapes)
+            shape.update();
+    };
+
     window.set_key_callback([&](View& view, KeyEvent ev){
         if (ev.action != Action::Press)
             return;
@@ -68,26 +91,27 @@ int main(int argc, const char* argv[])
             case Key::Escape:
                 window.close();
                 break;
+            case Key::F:
             case Key::F11:
                 window.toggle_fullscreen();
                 break;
             case Key::R:
-                add_shape_fn = [](Shape& shape, const ViewportRect& rect, ViewportUnits th) {
+                add_shape_fn = [](Shape& shape, const FramebufferRect& rect, FramebufferPixels th) {
                     shape.add_rectangle(rect, th);
                 };
                 break;
             case Key::O:
-                add_shape_fn = [](Shape& shape, const ViewportRect& rect, ViewportUnits th) {
-                    shape.add_rounded_rectangle(rect, 0.05f, th);
+                add_shape_fn = [&](Shape& shape, const FramebufferRect& rect, FramebufferPixels th) {
+                    shape.add_rounded_rectangle(rect, view.vp_to_fb(0.05_vp), th);
                 };
                 break;
             case Key::E:
-                add_shape_fn = [](Shape& shape, const ViewportRect& rect, ViewportUnits th) {
+                add_shape_fn = [](Shape& shape, const FramebufferRect& rect, FramebufferPixels th) {
                     shape.add_ellipse(rect, th);
                 };
                 break;
             case Key::L:
-                add_shape_fn = [](Shape& shape, const ViewportRect& rect, ViewportUnits th) {
+                add_shape_fn = [](Shape& shape, const FramebufferRect& rect, FramebufferPixels th) {
                     auto l = rect.left();
                     auto t = rect.top();
                     auto r = rect.right();
@@ -110,50 +134,28 @@ int main(int argc, const char* argv[])
                 softness = (softness == 0) ? 1 : 0;
                 break;
             default:
-                break;
+                return;
         }
+        recreate_shapes(view);
         view.refresh();
     });
 
     window.set_size_callback([&](View& view) {
         shapes_help.resize(view);
         option_help.resize(view);
-    });
-
-    window.set_update_callback([&](View& view, std::chrono::nanoseconds) {
-        shapes_help.update(view);
-        option_help.update(view);
-
-        for (Shape& shape : shapes) {
-            shape.clear();
-            set_shape_attr(shape);
-        }
-
-        // Border scaled with viewport size
-        add_shape_fn(shapes[0], {-1.0f, -0.6f, 2.0f, 1.2f}, 0.05f);
-        add_shape_fn(shapes[1], {-0.6f, -0.8f, 1.2f, 1.6f}, 0.02f);
-
-        // Constant border width, in screen pixels
-        add_shape_fn(shapes[2], {0.0f, 0.0f, 0.5f, 0.5f}, view.size_to_viewport(1_px));
-        add_shape_fn(shapes[3], {0.1f, 0.1f, 0.5f, 0.5f}, view.size_to_viewport(2_px));
-        add_shape_fn(shapes[4], {0.2f, 0.2f, 0.5f, 0.5f}, view.size_to_viewport(3_px));
-        add_shape_fn(shapes[5], {0.3f, 0.3f, 0.5f, 0.5f}, view.size_to_viewport(4_px));
-        add_shape_fn(shapes[6], {0.4f, 0.4f, 0.5f, 0.5f}, view.size_to_viewport(5_px));
-
-        for (Shape& shape : shapes)
-            shape.update();
+        recreate_shapes(view);
     });
 
     window.set_draw_callback([&](View& view) {
         auto vs = view.viewport_size();
-        shapes_help.draw(view, {-vs.x / 2 + 0.1f, -vs.y / 2 + 0.1f});
-        option_help.draw(view, {vs.x / 2 - 0.5f, -vs.y / 2 + 0.1f});
+        shapes_help.draw(view, {-vs.x / 2 + 0.1_vp, -vs.y / 2 + 0.1_vp});
+        option_help.draw(view, {vs.x / 2 - 0.5_vp, -vs.y / 2 + 0.1_vp});
 
-        shapes[0].draw(view, {0, 0});
-        shapes[1].draw(view, {0, 0});
+        shapes[0].draw(view, {0_vp, 0_vp});
+        shapes[1].draw(view, {0_vp, 0_vp});
 
         for (size_t i = 2; i <= 6; i++)
-            shapes[i].draw(view, {-0.45f, -0.45f});
+            shapes[i].draw(view, {-0.45_vp, -0.45_vp});
     });
 
     window.set_refresh_mode(RefreshMode::OnDemand);

--- a/examples/graphics/demo_vulkan.cpp
+++ b/examples/graphics/demo_vulkan.cpp
@@ -15,6 +15,8 @@
 
 #include <cstdlib>
 
+using namespace xci::graphics::unit_literals;
+
 
 void generate_checkerboard(Texture& texture)
 {
@@ -58,19 +60,7 @@ int main(int argc, const char* argv[])
     Primitives prim {renderer,
                      VertexFormat::V2c4t2, PrimitiveType::TriFans};
 
-    prim.begin_primitive();
-    prim.add_vertex({-1.0f, -1.0f}, {1.0f, 0.0f, 0.0f}, 0, 0);
-    prim.add_vertex({-1.0f, 0.0f}, {0.0f, 0.0f, 1.0f}, 0, 0);
-    prim.add_vertex({0.0f, 0.0f}, {1.0f, 0.0f, 1.0f}, 0, 0);
-    prim.add_vertex({0.0f, -1.0f}, {1.0f, 1.0f, 0.0f}, 0, 0);
-    prim.end_primitive();
 
-    prim.begin_primitive();
-    prim.add_vertex({-0.5f, -0.5f}, {1.0f, 0.0f, 0.0f}, 0, 0);
-    prim.add_vertex({-0.5f, 0.5f}, {0.0f, 1.0f, 0.0f}, 0, 1.0);
-    prim.add_vertex({0.5f, 0.5f}, {0.0f, 0.0f, 1.0f}, 1.0, 1.0);
-    prim.add_vertex({0.5f, -0.5f}, {1.0f, 1.0f, 0.0f}, 1.0, 0);
-    prim.end_primitive();
 
     Texture texture{renderer, ColorFormat::Grey};
     texture.create({256, 256});
@@ -87,14 +77,34 @@ int main(int argc, const char* argv[])
     shape.set_outline_color(Color(180, 180, 0));
     shape.set_softness(1);
     shape.set_antialiasing(1);
-    shape.add_rectangle({-0.75, -0.3f, 2.0f, 1.2f}, 0.05f);
 
-    prim.update();
-    shape.update();
+    window.set_size_callback([&](View& view) {
+        prim.clear();
+
+        prim.begin_primitive();
+        prim.add_vertex(view.vp_to_fb({-1.0f, -1.0f}), {1.0f, 0.0f, 0.0f}, 0, 0);
+        prim.add_vertex(view.vp_to_fb({-1.0f, 0.0f}), {0.0f, 0.0f, 1.0f}, 0, 0);
+        prim.add_vertex(view.vp_to_fb({0.0f, 0.0f}), {1.0f, 0.0f, 1.0f}, 0, 0);
+        prim.add_vertex(view.vp_to_fb({0.0f, -1.0f}), {1.0f, 1.0f, 0.0f}, 0, 0);
+        prim.end_primitive();
+
+        prim.begin_primitive();
+        prim.add_vertex(view.vp_to_fb({-0.5f, -0.5f}), {1.0f, 0.0f, 0.0f}, 0, 0);
+        prim.add_vertex(view.vp_to_fb({-0.5f, 0.5f}), {0.0f, 1.0f, 0.0f}, 0, 1.0);
+        prim.add_vertex(view.vp_to_fb({0.5f, 0.5f}), {0.0f, 0.0f, 1.0f}, 1.0, 1.0);
+        prim.add_vertex(view.vp_to_fb({0.5f, -0.5f}), {1.0f, 1.0f, 0.0f}, 1.0, 0);
+        prim.end_primitive();
+
+        prim.update();
+
+        shape.clear();
+        shape.add_rectangle(view.vp_to_fb({-0.75, -0.3f, 2.0f, 1.2f}), view.vp_to_fb(0.05f));
+        shape.update();
+    });
 
     window.set_draw_callback([&](View& view) {
         prim.draw(view);
-        shape.draw(view, {0, 0});
+        shape.draw(view, {0_fb, 0_fb});
     });
 
     window.set_refresh_mode(RefreshMode::OnDemand);

--- a/examples/graphics/demo_vulkan.cpp
+++ b/examples/graphics/demo_vulkan.cpp
@@ -1,7 +1,7 @@
 // demo_vulkan.cpp created on 2019-10-22 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2019 Radek Brich
+// Copyright 2019–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "common.h"
@@ -32,7 +32,7 @@ void generate_checkerboard(Texture& texture)
         }
     texture.write(pixels.data());
 
-    // replace sub-region of the texture
+    // replace subregion of the texture
     for (uint32_t i = 0; i != 50*50; ++i) {
         pixels[i] = 128;
     }
@@ -60,8 +60,6 @@ int main(int argc, const char* argv[])
     Primitives prim {renderer,
                      VertexFormat::V2c4t2, PrimitiveType::TriFans};
 
-
-
     Texture texture{renderer, ColorFormat::Grey};
     texture.create({256, 256});
     generate_checkerboard(texture);
@@ -82,23 +80,23 @@ int main(int argc, const char* argv[])
         prim.clear();
 
         prim.begin_primitive();
-        prim.add_vertex(view.vp_to_fb({-1.0f, -1.0f}), {1.0f, 0.0f, 0.0f}, 0, 0);
-        prim.add_vertex(view.vp_to_fb({-1.0f, 0.0f}), {0.0f, 0.0f, 1.0f}, 0, 0);
-        prim.add_vertex(view.vp_to_fb({0.0f, 0.0f}), {1.0f, 0.0f, 1.0f}, 0, 0);
-        prim.add_vertex(view.vp_to_fb({0.0f, -1.0f}), {1.0f, 1.0f, 0.0f}, 0, 0);
+        prim.add_vertex(view.vp_to_fb({-50_vp, -50_vp}), {1.0f, 0.0f, 0.0f}, 0, 0);
+        prim.add_vertex(view.vp_to_fb({-50_vp, 0_vp}), {0.0f, 0.0f, 1.0f}, 0, 0);
+        prim.add_vertex(view.vp_to_fb({0_vp, 0_vp}),  {1.0f, 0.0f, 1.0f}, 0, 0);
+        prim.add_vertex(view.vp_to_fb({0_vp, -50_vp}), {1.0f, 1.0f, 0.0f}, 0, 0);
         prim.end_primitive();
 
         prim.begin_primitive();
-        prim.add_vertex(view.vp_to_fb({-0.5f, -0.5f}), {1.0f, 0.0f, 0.0f}, 0, 0);
-        prim.add_vertex(view.vp_to_fb({-0.5f, 0.5f}), {0.0f, 1.0f, 0.0f}, 0, 1.0);
-        prim.add_vertex(view.vp_to_fb({0.5f, 0.5f}), {0.0f, 0.0f, 1.0f}, 1.0, 1.0);
-        prim.add_vertex(view.vp_to_fb({0.5f, -0.5f}), {1.0f, 1.0f, 0.0f}, 1.0, 0);
+        prim.add_vertex(view.vp_to_fb({-25_vp, -25_vp}), {1.0f, 0.0f, 0.0f}, 0, 0);
+        prim.add_vertex(view.vp_to_fb({-25_vp, 25_vp}), {0.0f, 1.0f, 0.0f}, 0, 1.0);
+        prim.add_vertex(view.vp_to_fb({25_vp, 25_vp}), {0.0f, 0.0f, 1.0f}, 1.0, 1.0);
+        prim.add_vertex(view.vp_to_fb({25_vp, -25_vp}), {1.0f, 1.0f, 0.0f}, 1.0, 0);
         prim.end_primitive();
 
         prim.update();
 
         shape.clear();
-        shape.add_rectangle(view.vp_to_fb({-0.75, -0.3f, 2.0f, 1.2f}), view.vp_to_fb(0.05f));
+        shape.add_rectangle(view.vp_to_fb({-37.5_vp, -15_vp, 100_vp, 60_vp}), view.vp_to_fb(2.5_vp));
         shape.update();
     });
 

--- a/examples/text/demo_font.cpp
+++ b/examples/text/demo_font.cpp
@@ -116,8 +116,8 @@ int main(int argc, const char* argv[])
 
         auto enl_rect = rect.enlarged(0.01f);
         rects.clear();
-        rects.add_rectangle(enl_rect, view.size_to_viewport(1_sc));
-        rects.add_rectangle(enl_rect.moved({0, emoji_offset}), view.size_to_viewport(1_sc));
+        rects.add_rectangle(enl_rect, view.size_to_viewport(1_px));
+        rects.add_rectangle(enl_rect.moved({0, emoji_offset}), view.size_to_viewport(1_px));
         rects.update();
     });
 

--- a/examples/text/demo_font.cpp
+++ b/examples/text/demo_font.cpp
@@ -57,7 +57,7 @@ int main(int argc, const char* argv[])
     if (!emoji_font.add_face(vfs, "fonts/Noto/NotoColorEmoji.ttf", 0))
         return EXIT_FAILURE;
 
-    static constexpr float text_font_size = 0.1f;
+    static constexpr ViewportUnits text_font_size = 0.1_vp;
     Text text;
     text.set_markup_string(sample_text);
     text.set_font(font);
@@ -67,7 +67,7 @@ int main(int argc, const char* argv[])
     Text emoji;
     emoji.set_markup_string("🥛🍸🥃🥂🍷🍹⚗️🧂");
     emoji.set_font(emoji_font);
-    emoji.set_font_size(0.2f);
+    emoji.set_font_size(0.2_vp);
 
     static constexpr auto help_color_normal = Color(200, 100, 50);
     static constexpr auto help_color_highlight = Color(255, 170, 120);
@@ -75,7 +75,7 @@ int main(int argc, const char* argv[])
                          "<font><b>[f]</b> font scaling</font><br>"
                          "(Resize window to observe the scaling effect.)", Text::Format::Markup);
     help_text.set_color(help_color_normal);
-    help_text.set_font_size(0.1f);
+    help_text.set_font_size(0.1_vp);
 
     auto help_highlight = [&help_text, &text](const View& view) {
         bool smooth = text.layout().default_style().allow_scale();
@@ -94,7 +94,7 @@ int main(int argc, const char* argv[])
     Shape rects(renderer, Color::Transparent(),
             Color(0.7, 0.7, 0.7));
 
-    ViewportUnits emoji_offset = 0.f;
+    FramebufferPixels emoji_offset = 0.f;
 
     window.set_size_callback([&](View& view) {
         text.resize(view);
@@ -102,8 +102,8 @@ int main(int argc, const char* argv[])
         help_text.resize(view);
         help_highlight(view);
 
-        auto tex_size = view.size_to_viewport(FramebufferSize{font.texture().size()});
-        ViewportRect rect = {0, 0, tex_size.x, tex_size.y};
+        auto tex_size = FramebufferSize{font.texture().size()};
+        FramebufferRect rect = {0, 0, tex_size.x, tex_size.y};
         emoji_offset = rect.size().y + 0.04f;
 
         font_texture.clear();
@@ -116,26 +116,27 @@ int main(int argc, const char* argv[])
 
         auto enl_rect = rect.enlarged(0.01f);
         rects.clear();
-        rects.add_rectangle(enl_rect, view.size_to_viewport(1_px));
-        rects.add_rectangle(enl_rect.moved({0, emoji_offset}), view.size_to_viewport(1_px));
+        rects.add_rectangle(enl_rect, view.px_to_fb(1_px));
+        rects.add_rectangle(enl_rect.moved({0, emoji_offset}), view.px_to_fb(1_px));
         rects.update();
     });
 
     window.set_draw_callback([&](View& view) {
         auto vs = view.viewport_size();
-        ViewportCoords font_pos {-0.5f * vs.x + 0.01f, -0.5f * vs.y + 0.01f};
+        ViewportCoords font_pos {-0.5 * vs.x + 0.01_vp, -0.5f * vs.y + 0.01_vp};
         rects.draw(view, font_pos);
         font_texture.draw(view, font_pos);
-        font_pos.y += emoji_offset;
+        font_pos.y += view.fb_to_vp(emoji_offset);
         emoji_font_texture.draw(view, font_pos);
 
         // font texture width
-        auto fw = view.size_to_viewport(FramebufferSize{font.texture().size()}).x;
+        auto fw = view.fb_to_vp(font.texture().size().x);
+        auto ew = view.fb_to_vp(emoji.layout().bbox().w);
         auto tx = -vs.x * 0.5f + fw  // the font box right edge
-                + (vs.x - fw - emoji.layout().bbox().w) / 2;  // half of empty space left around text
-        text.draw(view, {tx, -0.55f});
-        emoji.draw(view, {tx, -0.70f});
-        help_text.draw(view, {tx, 0.70f});
+                + (vs.x - fw - ew) / 2;  // half of empty space left around text
+        text.draw(view, {tx, -0.55_vp});
+        emoji.draw(view, {tx, -0.70_vp});
+        help_text.draw(view, {tx, 0.70_vp});
     });
 
     window.set_key_callback([&](View& view, KeyEvent ev) {

--- a/examples/text/demo_font.cpp
+++ b/examples/text/demo_font.cpp
@@ -1,7 +1,7 @@
 // demo_font.cpp created on 2018-03-02 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "graphics/common.h"
@@ -57,7 +57,7 @@ int main(int argc, const char* argv[])
     if (!emoji_font.add_face(vfs, "fonts/Noto/NotoColorEmoji.ttf", 0))
         return EXIT_FAILURE;
 
-    static constexpr ViewportUnits text_font_size = 0.1_vp;
+    static constexpr ViewportUnits text_font_size = 5_vp;
     Text text;
     text.set_markup_string(sample_text);
     text.set_font(font);
@@ -67,7 +67,7 @@ int main(int argc, const char* argv[])
     Text emoji;
     emoji.set_markup_string("🥛🍸🥃🥂🍷🍹⚗️🧂");
     emoji.set_font(emoji_font);
-    emoji.set_font_size(0.2_vp);
+    emoji.set_font_size(10_vp);
 
     static constexpr auto help_color_normal = Color(200, 100, 50);
     static constexpr auto help_color_highlight = Color(255, 170, 120);
@@ -75,7 +75,7 @@ int main(int argc, const char* argv[])
                          "<font><b>[f]</b> font scaling</font><br>"
                          "(Resize window to observe the scaling effect.)", Text::Format::Markup);
     help_text.set_color(help_color_normal);
-    help_text.set_font_size(0.1_vp);
+    help_text.set_font_size(5_vp);
 
     auto help_highlight = [&help_text, &text](const View& view) {
         bool smooth = text.layout().default_style().allow_scale();
@@ -123,7 +123,7 @@ int main(int argc, const char* argv[])
 
     window.set_draw_callback([&](View& view) {
         auto vs = view.viewport_size();
-        ViewportCoords font_pos {-0.5 * vs.x + 0.01_vp, -0.5f * vs.y + 0.01_vp};
+        ViewportCoords font_pos {-0.5f * vs.x + 0.5_vp, -0.5f * vs.y + 0.5_vp};
         rects.draw(view, font_pos);
         font_texture.draw(view, font_pos);
         font_pos.y += view.fb_to_vp(emoji_offset);
@@ -134,9 +134,9 @@ int main(int argc, const char* argv[])
         auto ew = view.fb_to_vp(emoji.layout().bbox().w);
         auto tx = -vs.x * 0.5f + fw  // the font box right edge
                 + (vs.x - fw - ew) / 2;  // half of empty space left around text
-        text.draw(view, {tx, -0.55_vp});
-        emoji.draw(view, {tx, -0.70_vp});
-        help_text.draw(view, {tx, 0.70_vp});
+        text.draw(view, {tx, -27.5_vp});
+        emoji.draw(view, {tx, -35_vp});
+        help_text.draw(view, {tx, 35_vp});
     });
 
     window.set_key_callback([&](View& view, KeyEvent ev) {

--- a/examples/text/demo_layout.cpp
+++ b/examples/text/demo_layout.cpp
@@ -1,7 +1,7 @@
 // demo_layout.cpp created on 2018-03-10 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "graphics/common.h"
@@ -59,9 +59,9 @@ int main(int argc, const char* argv[])
 
     Text text;
     text.set_markup_string(sample_text);
-    text.set_width(1.33_vp);
+    text.set_width(66.5_vp);
     text.set_font(font);
-    text.set_font_size(0.09_vp);
+    text.set_font_size(4.5_vp);
     text.set_font_style(FontStyle::Italic);
     text.set_font_weight(font_weight);
     text.set_color(Color::White());
@@ -73,17 +73,17 @@ int main(int argc, const char* argv[])
                          "[l] show line boxes\n"
                          "[s] show span boxes\n"
                          "[p] show page boxes\n");
-    help_text.set_tab_stops({0.8_vp});
+    help_text.set_tab_stops({4_vp});
     help_text.set_color(Color(50, 200, 100));
-    help_text.set_font_size(0.06_vp);
+    help_text.set_font_size(3_vp);
 
     Text help_text_2(mono_font, fmt::format("[+]/[-] Font weight: {}", font_weight));
     help_text_2.set_color(Color(50, 200, 100));
-    help_text_2.set_font_size(0.06_vp);
+    help_text_2.set_font_size(3_vp);
 
     Text help_text_3(font, "Resize the window to watch the reflow.");
     help_text_3.set_color(Color(200, 100, 50));
-    help_text_3.set_font_size(0.07_vp);
+    help_text_3.set_font_size(3.5_vp);
 
     Sprites font_texture(renderer, font.texture(), Color(0, 50, 255));
 
@@ -177,13 +177,13 @@ int main(int argc, const char* argv[])
     });
 
     window.set_draw_callback([&](View& view) {
-        help_text.draw(view, {-0.17_vp, -0.9_vp});
-        help_text_2.draw(view, {-0.17_vp, 0.75_vp});
-        help_text_3.draw(view, {-0.17_vp, 0.9_vp});
-        text.draw(view, {-0.17_vp, -0.4_vp});
+        help_text.draw(view, {-8.5_vp, -45_vp});
+        help_text_2.draw(view, {-8.5_vp, 37.5_vp});
+        help_text_3.draw(view, {-8.5_vp, 45_vp});
+        text.draw(view, {-8.5_vp, -20_vp});
 
-        font_texture.draw(view, {-0.5f * view.viewport_size().x + 0.01f,
-                                 -0.5f * view.viewport_size().y + 0.01f});
+        font_texture.draw(view, {-0.5f * view.viewport_size().x + 0.5_vp,
+                                 -0.5f * view.viewport_size().y + 0.5_vp});
     });
 
     window.display();

--- a/examples/text/demo_layout.cpp
+++ b/examples/text/demo_layout.cpp
@@ -20,6 +20,7 @@ using namespace xci::core;
 
 // TODO: * justify
 //       * demonstrate setting attributes on a span
+// FIXME: comma may land on next line when reflowed
 
 static const char * sample_text =
         "Each paragraph is broken into lines. "
@@ -58,9 +59,9 @@ int main(int argc, const char* argv[])
 
     Text text;
     text.set_markup_string(sample_text);
-    text.set_width(1.33f);
+    text.set_width(1.33_vp);
     text.set_font(font);
-    text.set_font_size(0.09f);
+    text.set_font_size(0.09_vp);
     text.set_font_style(FontStyle::Italic);
     text.set_font_weight(font_weight);
     text.set_color(Color::White());
@@ -72,17 +73,17 @@ int main(int argc, const char* argv[])
                          "[l] show line boxes\n"
                          "[s] show span boxes\n"
                          "[p] show page boxes\n");
-    help_text.set_tab_stops({0.8f});
+    help_text.set_tab_stops({0.8_vp});
     help_text.set_color(Color(50, 200, 100));
-    help_text.set_font_size(0.06f);
+    help_text.set_font_size(0.06_vp);
 
     Text help_text_2(mono_font, fmt::format("[+]/[-] Font weight: {}", font_weight));
     help_text_2.set_color(Color(50, 200, 100));
-    help_text_2.set_font_size(0.06f);
+    help_text_2.set_font_size(0.06_vp);
 
     Text help_text_3(font, "Resize the window to watch the reflow.");
     help_text_3.set_color(Color(200, 100, 50));
-    help_text_3.set_font_size(0.07f);
+    help_text_3.set_font_size(0.07_vp);
 
     Sprites font_texture(renderer, font.texture(), Color(0, 50, 255));
 
@@ -165,10 +166,9 @@ int main(int argc, const char* argv[])
         text.set_width(view.viewport_size().x / 2.f);
         text.resize(view);
 
-        auto tex_size = view.size_to_viewport(FramebufferSize{font.texture().size()});
-        ViewportRect rect = {0, 0, tex_size.x, tex_size.y};
+        auto tex_size = FramebufferSize{font.texture().size()};
         font_texture.clear();
-        font_texture.add_sprite(rect);
+        font_texture.add_sprite({0, 0, tex_size.x, tex_size.y});
         font_texture.update();
     });
 
@@ -177,10 +177,10 @@ int main(int argc, const char* argv[])
     });
 
     window.set_draw_callback([&](View& view) {
-        help_text.draw(view, {-0.17f, -0.9f});
-        help_text_2.draw(view, {-0.17f, 0.75f});
-        help_text_3.draw(view, {-0.17f, 0.9f});
-        text.draw(view, {-0.17f, -0.4f});
+        help_text.draw(view, {-0.17_vp, -0.9_vp});
+        help_text_2.draw(view, {-0.17_vp, 0.75_vp});
+        help_text_3.draw(view, {-0.17_vp, 0.9_vp});
+        text.draw(view, {-0.17_vp, -0.4_vp});
 
         font_texture.draw(view, {-0.5f * view.viewport_size().x + 0.01f,
                                  -0.5f * view.viewport_size().y + 0.01f});

--- a/examples/text/demo_outline.cpp
+++ b/examples/text/demo_outline.cpp
@@ -48,13 +48,13 @@ int main(int argc, const char* argv[])
     if (!mono_font.add_face(vfs, "fonts/ShareTechMono/ShareTechMono-Regular.ttf", 0))
         return EXIT_FAILURE;
 
-    ViewportUnits outline_radius = 0.002f;
+    ScreenPixels outline_radius = 1_px;
 
     Text text;
     text.set_markup_string(sample_text);
-    text.set_width(1.33f);
+    text.set_width(1.33_vp);
     text.set_font(font);
-    text.set_font_size(0.09f);
+    text.set_font_size(0.09_vp);
     text.set_outline_radius(outline_radius);
 
     auto apply_spans = [&layout = text.layout()](const View& view) {
@@ -79,13 +79,13 @@ int main(int argc, const char* argv[])
 
     Text help_text(mono_font, "[+] thicker outline\n"
                               "[-] thinner outline\n");
-    help_text.set_tab_stops({0.8f});
+    help_text.set_tab_stops({0.8_vp});
     help_text.set_color(Color(50, 200, 100));
-    help_text.set_font_size(0.06f);
+    help_text.set_font_size(0.06_vp);
 
-    Text info_text(font, fmt::format("Outline radius: {}", outline_radius));
+    Text info_text(font, fmt::format("Outline radius: {} px", outline_radius));
     info_text.set_color(Color(200, 100, 50));
-    info_text.set_font_size(0.07f);
+    info_text.set_font_size(0.07_vp);
 
     Sprites font_texture(renderer, font.texture(), Color(0, 50, 255));
 
@@ -101,13 +101,13 @@ int main(int argc, const char* argv[])
                 break;
             case Key::Minus:  // -/_ key
             case Key::KeypadSubtract:
-                outline_radius -= 0.0005f;
+                outline_radius -= 0.1f;
                 if (outline_radius < 0.0f)
                     outline_radius = 0.0f;
                 break;
             case Key::Equal:  // =/+ key
             case Key::KeypadAdd:
-                outline_radius += 0.0005f;
+                outline_radius += 0.1f;
                 break;
             default:
                 return;
@@ -116,7 +116,7 @@ int main(int argc, const char* argv[])
         text.update(view);
         apply_spans(view);
 
-        info_text.set_string(fmt::format("Outline radius: {}", outline_radius));
+        info_text.set_string(fmt::format("Outline radius: {} px", outline_radius));
         info_text.update(view);
 
         view.refresh();
@@ -132,10 +132,9 @@ int main(int argc, const char* argv[])
         text.resize(view);
         apply_spans(view);
 
-        auto tex_size = view.size_to_viewport(FramebufferSize{font.texture().size()});
-        ViewportRect rect = {0, 0, tex_size.x, tex_size.y};
+        auto tex_size = FramebufferSize{font.texture().size()};
         font_texture.clear();
-        font_texture.add_sprite(rect);
+        font_texture.add_sprite({0, 0, tex_size.x, tex_size.y});
         font_texture.update();
     });
 
@@ -144,12 +143,12 @@ int main(int argc, const char* argv[])
     });
 
     window.set_draw_callback([&](View& view) {
-        help_text.draw(view, {-0.17f, -0.9f});
-        info_text.draw(view, {-0.17f, 0.9f});
-        text.draw(view, {-0.17f, -0.4f});
+        help_text.draw(view, {-0.17_vp, -0.9_vp});
+        info_text.draw(view, {-0.17_vp, 0.9_vp});
+        text.draw(view, {-0.17_vp, -0.4_vp});
 
-        font_texture.draw(view, {-0.5f * view.viewport_size().x + 0.01f,
-                                 -0.5f * view.viewport_size().y + 0.01f});
+        font_texture.draw(view, {-0.5_vp * view.viewport_size().x + 0.01_vp,
+                                 -0.5_vp * view.viewport_size().y + 0.01_vp});
     });
 
     window.display();

--- a/examples/text/demo_outline.cpp
+++ b/examples/text/demo_outline.cpp
@@ -1,7 +1,7 @@
 // demo_outline.cpp created on 2021-11-21 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2021 Radek Brich
+// Copyright 2021–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "graphics/common.h"
@@ -52,9 +52,9 @@ int main(int argc, const char* argv[])
 
     Text text;
     text.set_markup_string(sample_text);
-    text.set_width(1.33_vp);
+    text.set_width(66.5_vp);
     text.set_font(font);
-    text.set_font_size(0.09_vp);
+    text.set_font_size(4.5_vp);
     text.set_outline_radius(outline_radius);
 
     auto apply_spans = [&layout = text.layout()](const View& view) {
@@ -79,13 +79,13 @@ int main(int argc, const char* argv[])
 
     Text help_text(mono_font, "[+] thicker outline\n"
                               "[-] thinner outline\n");
-    help_text.set_tab_stops({0.8_vp});
+    help_text.set_tab_stops({40_vp});
     help_text.set_color(Color(50, 200, 100));
-    help_text.set_font_size(0.06_vp);
+    help_text.set_font_size(3_vp);
 
     Text info_text(font, fmt::format("Outline radius: {} px", outline_radius));
     info_text.set_color(Color(200, 100, 50));
-    info_text.set_font_size(0.07_vp);
+    info_text.set_font_size(3.5_vp);
 
     Sprites font_texture(renderer, font.texture(), Color(0, 50, 255));
 
@@ -143,12 +143,12 @@ int main(int argc, const char* argv[])
     });
 
     window.set_draw_callback([&](View& view) {
-        help_text.draw(view, {-0.17_vp, -0.9_vp});
-        info_text.draw(view, {-0.17_vp, 0.9_vp});
-        text.draw(view, {-0.17_vp, -0.4_vp});
+        help_text.draw(view, {-8.5_vp, -45_vp});
+        info_text.draw(view, {-8.5_vp, 45_vp});
+        text.draw(view, {-8.5_vp, -20_vp});
 
-        font_texture.draw(view, {-0.5_vp * view.viewport_size().x + 0.01_vp,
-                                 -0.5_vp * view.viewport_size().y + 0.01_vp});
+        font_texture.draw(view, {-0.5f * view.viewport_size().x + 0.5_vp,
+                                 -0.5f * view.viewport_size().y + 0.5_vp});
     });
 
     window.display();

--- a/examples/widgets/MousePosInfo.h
+++ b/examples/widgets/MousePosInfo.h
@@ -30,6 +30,7 @@ public:
     }
 
     void resize(View& view) override {
+        Widget::resize(view);
         m_text.resize(view);
     }
 

--- a/examples/widgets/demo_form.cpp
+++ b/examples/widgets/demo_form.cpp
@@ -40,7 +40,7 @@ int main(int argc, const char* argv[])
 
     // Form #1
     Form form1 {theme};
-    form1.set_position({-1.0f, -0.5f});
+    form1.set_position({-1.0_vp, -0.5_vp});
     root.add(form1);
 
     std::string input_text = "2018-06-23";
@@ -58,7 +58,7 @@ int main(int argc, const char* argv[])
 
     // Form #1 output
     Label output_text(theme);
-    output_text.set_position({0.2f, -0.5f});
+    output_text.set_position({0.2_vp, -0.5_vp});
     output_text.text().set_color(Color(180, 100, 140));
     button.on_click([&output_text, &input_text, &checkbox1, &checkbox2]
                      (View& view) {
@@ -74,7 +74,7 @@ int main(int argc, const char* argv[])
 
     // Form #2
     Form form2(theme);
-    form2.set_position({-1.0f, 0.2f});
+    form2.set_position({-1.0_vp, 0.2_vp});
     root.add(form2);
 
     std::string name = "Player1";
@@ -85,12 +85,12 @@ int main(int argc, const char* argv[])
 
     // Mouse pos
     MousePosInfo mouse_pos_info(theme);
-    mouse_pos_info.set_position({-1.2f, 0.9f});
+    mouse_pos_info.set_position({-1.2_vp, 0.9_vp});
     root.add(mouse_pos_info);
 
     // FPS
     FpsDisplay fps_display(theme);
-    fps_display.set_position({-1.2f, -0.8f});
+    fps_display.set_position({-1.2_vp, -0.8_vp});
     root.add(fps_display);
 
     window.set_refresh_mode(RefreshMode::OnDemand);

--- a/examples/widgets/demo_form.cpp
+++ b/examples/widgets/demo_form.cpp
@@ -1,7 +1,7 @@
 // demo_form.cpp created on 2018-06-23 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "MousePosInfo.h"
@@ -40,7 +40,7 @@ int main(int argc, const char* argv[])
 
     // Form #1
     Form form1 {theme};
-    form1.set_position({-1.0_vp, -0.5_vp});
+    form1.set_position({-50_vp, -25_vp});
     root.add(form1);
 
     std::string input_text = "2018-06-23";
@@ -58,7 +58,7 @@ int main(int argc, const char* argv[])
 
     // Form #1 output
     Label output_text(theme);
-    output_text.set_position({0.2_vp, -0.5_vp});
+    output_text.set_position({10_vp, -25_vp});
     output_text.text().set_color(Color(180, 100, 140));
     button.on_click([&output_text, &input_text, &checkbox1, &checkbox2]
                      (View& view) {
@@ -74,7 +74,7 @@ int main(int argc, const char* argv[])
 
     // Form #2
     Form form2(theme);
-    form2.set_position({-1.0_vp, 0.2_vp});
+    form2.set_position({-50_vp, 10_vp});
     root.add(form2);
 
     std::string name = "Player1";
@@ -85,12 +85,12 @@ int main(int argc, const char* argv[])
 
     // Mouse pos
     MousePosInfo mouse_pos_info(theme);
-    mouse_pos_info.set_position({-1.2_vp, 0.9_vp});
+    mouse_pos_info.set_position({-60_vp, 45_vp});
     root.add(mouse_pos_info);
 
     // FPS
     FpsDisplay fps_display(theme);
-    fps_display.set_position({-1.2_vp, -0.8_vp});
+    fps_display.set_position({-60_vp, -40_vp});
     root.add(fps_display);
 
     window.set_refresh_mode(RefreshMode::OnDemand);

--- a/examples/widgets/demo_term_dispatch.cpp
+++ b/examples/widgets/demo_term_dispatch.cpp
@@ -120,8 +120,8 @@ int main(int argc, const char* argv[])
     });
 
     Bind bind(window, terminal);
-    window.set_refresh_mode(RefreshMode::OnDemand);
-    window.set_view_mode(ViewOrigin::TopLeft, ViewScale::FixedScreenPixels);
+    window.set_refresh_mode(RefreshMode::Periodic);  // FIXME: bell() doesn't work with OnDemand
+    window.set_view_mode(ViewOrigin::TopLeft);
     window.display();
 
     dispatch.terminate();

--- a/examples/widgets/demo_term_dispatch.cpp
+++ b/examples/widgets/demo_term_dispatch.cpp
@@ -1,7 +1,7 @@
 // demo_term_dispatch.cpp created on 2019-04-06 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2019–2021 Radek Brich
+// Copyright 2019–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "graphics/common.h"
@@ -121,7 +121,7 @@ int main(int argc, const char* argv[])
 
     Bind bind(window, terminal);
     window.set_refresh_mode(RefreshMode::Periodic);  // FIXME: bell() doesn't work with OnDemand
-    window.set_view_mode(ViewOrigin::TopLeft);
+    window.set_view_origin(ViewOrigin::TopLeft);
     window.display();
 
     dispatch.terminate();

--- a/examples/widgets/demo_term_widget.cpp
+++ b/examples/widgets/demo_term_widget.cpp
@@ -1,7 +1,7 @@
 // demo_term_widget.cpp created on 2018-07-19 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "graphics/common.h"
@@ -182,7 +182,7 @@ int main(int argc, const char* argv[])
 
     Bind bind(window, terminal);
     window.set_refresh_mode(RefreshMode::OnDemand);
-    window.set_view_mode(ViewOrigin::TopLeft);
+    window.set_view_origin(ViewOrigin::TopLeft);
     window.display();
     return EXIT_SUCCESS;
 }

--- a/examples/widgets/demo_term_widget.cpp
+++ b/examples/widgets/demo_term_widget.cpp
@@ -40,7 +40,7 @@ int main(int argc, const char* argv[])
 
     TextTerminal terminal {theme};
     terminal.set_size_in_cells({100, 50});
-    terminal.set_font_size(18.f);
+    terminal.set_font_size(18_px);
     terminal.add_text(prompt);
     terminal.set_font_style(TextTerminal::FontStyle::Bold);
     terminal.add_text(std::string(cmd) + "\n");
@@ -141,13 +141,14 @@ int main(int argc, const char* argv[])
     terminal.set_font_style(TextTerminal::FontStyle::BoldItalic);
     terminal.add_text("BoldItalic\n");
 
-    terminal.set_position({5, 0});
+    terminal.set_position({5_px, 0_px});
 
     // Make the terminal fullscreen
-    window.set_size_callback([&](View& v) {
-        auto vs = v.viewport_size();
-        vs.x -= 10_vp;
+    window.set_size_callback([&](View& view) {
+        auto vs = view.screen_size();
+        vs.x -= 10_px;
         terminal.set_size(vs);
+        view.refresh();
     });
 
     window.set_key_callback([&](View& view, const KeyEvent& ev) {
@@ -181,7 +182,7 @@ int main(int argc, const char* argv[])
 
     Bind bind(window, terminal);
     window.set_refresh_mode(RefreshMode::OnDemand);
-    window.set_view_mode(ViewOrigin::TopLeft, ViewScale::FixedScreenPixels);
+    window.set_view_mode(ViewOrigin::TopLeft);
     window.display();
     return EXIT_SUCCESS;
 }

--- a/examples/widgets/demo_ui.cpp
+++ b/examples/widgets/demo_ui.cpp
@@ -1,7 +1,7 @@
 // demo_ui.cpp created on 2018-04-22 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "MousePosInfo.h"
@@ -45,14 +45,14 @@ int main(int argc, const char* argv[])
     std::deque<TextInput> text_inputs;
     for (auto i : {0,1,2,3,4}) {
         text_inputs.emplace_back(theme, "input");
-        text_inputs.back().set_position({-1.0_vp, -0.5_vp + i * 0.12f});
+        text_inputs.back().set_position({-50_vp, -25_vp + i * 6_vp});
         root.add(text_inputs.back());
     }
 
     std::deque<Button> buttons;
     for (auto i : {0,1,2,3,4}) {
         buttons.emplace_back(theme, std::to_string(i+1) + ". click me!");
-        buttons.back().set_position({-0.2_vp, -0.5_vp + i * 0.12f});
+        buttons.back().set_position({-10_vp, -25_vp + i * 6_vp});
         auto* btn_self = &buttons.back();
         buttons.back().on_click([btn_self, &random_color](View& view) {
             view.finish_draw();
@@ -66,16 +66,16 @@ int main(int argc, const char* argv[])
     for (auto i : {0,1,2,3,4}) {
         checkboxes.emplace_back(theme);
         checkboxes.back().set_text("Checkbox " + std::to_string(i+1));
-        checkboxes.back().set_position({0.5_vp, -0.5_vp + i * 0.06f});
+        checkboxes.back().set_position({25_vp, -25_vp + i * 3_vp});
         root.add(checkboxes.back());
     }
 
     MousePosInfo mouse_pos_info {theme};
-    mouse_pos_info.set_position({-1.2_vp, 0.9_vp});
+    mouse_pos_info.set_position({-60_vp, 45_vp});
     root.add(mouse_pos_info);
 
     FpsDisplay fps_display {theme};
-    fps_display.set_position({-1.2_vp, -0.8_vp});
+    fps_display.set_position({-60_vp, -40_vp});
     root.add(fps_display);
 
     window.set_key_callback([&](View& view, KeyEvent ev) {

--- a/examples/widgets/demo_ui.cpp
+++ b/examples/widgets/demo_ui.cpp
@@ -45,14 +45,14 @@ int main(int argc, const char* argv[])
     std::deque<TextInput> text_inputs;
     for (auto i : {0,1,2,3,4}) {
         text_inputs.emplace_back(theme, "input");
-        text_inputs.back().set_position({-1.0f, -0.5f + i * 0.12f});
+        text_inputs.back().set_position({-1.0_vp, -0.5_vp + i * 0.12f});
         root.add(text_inputs.back());
     }
 
     std::deque<Button> buttons;
     for (auto i : {0,1,2,3,4}) {
         buttons.emplace_back(theme, std::to_string(i+1) + ". click me!");
-        buttons.back().set_position({-0.2f, -0.5f + i * 0.12f});
+        buttons.back().set_position({-0.2_vp, -0.5_vp + i * 0.12f});
         auto* btn_self = &buttons.back();
         buttons.back().on_click([btn_self, &random_color](View& view) {
             view.finish_draw();
@@ -66,16 +66,16 @@ int main(int argc, const char* argv[])
     for (auto i : {0,1,2,3,4}) {
         checkboxes.emplace_back(theme);
         checkboxes.back().set_text("Checkbox " + std::to_string(i+1));
-        checkboxes.back().set_position({0.5f, -0.5f + i * 0.06f});
+        checkboxes.back().set_position({0.5_vp, -0.5_vp + i * 0.06f});
         root.add(checkboxes.back());
     }
 
     MousePosInfo mouse_pos_info {theme};
-    mouse_pos_info.set_position({-1.2f, 0.9f});
+    mouse_pos_info.set_position({-1.2_vp, 0.9_vp});
     root.add(mouse_pos_info);
 
     FpsDisplay fps_display {theme};
-    fps_display.set_position({-1.2f, -0.8f});
+    fps_display.set_position({-1.2_vp, -0.8_vp});
     root.add(fps_display);
 
     window.set_key_callback([&](View& view, KeyEvent ev) {
@@ -86,6 +86,7 @@ int main(int argc, const char* argv[])
                 window.close();
                 break;
             case Key::F11:
+            case Key::F:
                 window.toggle_fullscreen();
                 break;
             case Key::R:

--- a/examples/widgets/demo_widgets.cpp
+++ b/examples/widgets/demo_widgets.cpp
@@ -55,7 +55,7 @@ int main(int argc, const char* argv[])
         //view.set_debug_flag(View::Debug::WordBasePoint);
         //view.set_debug_flag(View::Debug::PageBBox);
         button_default.resize(view);
-        button_styled.set_outline_thickness(view.size_to_viewport(1_sc));
+        button_styled.set_outline_thickness(view.size_to_viewport(1_px));
         button_styled.resize(view);
         checkbox.resize(view);
     });

--- a/examples/widgets/demo_widgets.cpp
+++ b/examples/widgets/demo_widgets.cpp
@@ -1,7 +1,7 @@
 // demo_widget.cpp created on 2018-03-20 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "graphics/common.h"
@@ -33,19 +33,19 @@ int main(int argc, const char* argv[])
         return EXIT_FAILURE;
 
     Button button_default(theme, "Default button");
-    button_default.set_position({0_vp, -0.2_vp});
+    button_default.set_position({0_vp, -10_vp});
 
     Button button_styled(theme, "Styled button");
-    button_styled.set_font_size(0.07_vp);
-    button_styled.set_padding(0.05_vp);
+    button_styled.set_font_size(3.5_vp);
+    button_styled.set_padding(2.5_vp);
     button_styled.set_decoration_color(Color(10, 20, 100), Color(20, 50, 150));
     button_styled.set_text_color(Color(255, 255, 50));
 
     Icon checkbox(theme);
-    checkbox.set_position({0_vp, 0.4_vp});
+    checkbox.set_position({0_vp, 20_vp});
     checkbox.set_icon(IconId::CheckBoxChecked);
     checkbox.set_text("Checkbox");
-    checkbox.set_font_size(0.08_vp);
+    checkbox.set_font_size(4_vp);
     checkbox.set_color(Color(150, 200, 200));
     bool checkbox_state = true;
     bool checkbox_active = false;

--- a/examples/widgets/demo_widgets.cpp
+++ b/examples/widgets/demo_widgets.cpp
@@ -33,19 +33,19 @@ int main(int argc, const char* argv[])
         return EXIT_FAILURE;
 
     Button button_default(theme, "Default button");
-    button_default.set_position({0, -0.2f});
+    button_default.set_position({0_vp, -0.2_vp});
 
     Button button_styled(theme, "Styled button");
-    button_styled.set_font_size(0.07f);
-    button_styled.set_padding(0.05f);
+    button_styled.set_font_size(0.07_vp);
+    button_styled.set_padding(0.05_vp);
     button_styled.set_decoration_color(Color(10, 20, 100), Color(20, 50, 150));
     button_styled.set_text_color(Color(255, 255, 50));
 
     Icon checkbox(theme);
-    checkbox.set_position({0, 0.4f});
+    checkbox.set_position({0_vp, 0.4_vp});
     checkbox.set_icon(IconId::CheckBoxChecked);
     checkbox.set_text("Checkbox");
-    checkbox.set_font_size(0.08f);
+    checkbox.set_font_size(0.08_vp);
     checkbox.set_color(Color(150, 200, 200));
     bool checkbox_state = true;
     bool checkbox_active = false;
@@ -55,7 +55,7 @@ int main(int argc, const char* argv[])
         //view.set_debug_flag(View::Debug::WordBasePoint);
         //view.set_debug_flag(View::Debug::PageBBox);
         button_default.resize(view);
-        button_styled.set_outline_thickness(view.size_to_viewport(1_px));
+        button_styled.set_outline_thickness(1_px);
         button_styled.resize(view);
         checkbox.resize(view);
     });

--- a/src/xci/core/geometry.h
+++ b/src/xci/core/geometry.h
@@ -1,7 +1,7 @@
 // geometry.h created on 2018-03-04 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_CORE_GEOMETRY_H
@@ -25,7 +25,7 @@ typename T::numeric_type cast_to_numeric(T var)
 
 template <typename T>
 struct Vec2 {
-    Vec2() : x(0), y(0) {}
+    Vec2() = default;
     Vec2(T x, T y) : x(x), y(y) {}
 
     // Convert another type of vector (possibly foreign type)
@@ -61,9 +61,21 @@ struct Vec2 {
         return std::abs(dx) + std::abs(dy);
     }
 
+    Vec2<T>& operator +=(const Vec2<T>& rhs) {
+        x += rhs.x;
+        y += rhs.y;
+        return *this;
+    }
+
+    Vec2<T>& operator -=(const Vec2<T>& rhs) {
+        x -= rhs.x;
+        y -= rhs.y;
+        return *this;
+    }
+
 public:
-    T x;
-    T y;
+    T x {};
+    T y {};
 };
 
 // unary minus (opposite vector)
@@ -110,20 +122,6 @@ Vec2<T> operator /(const Vec2<T>& lhs, const Vec2<T>& rhs) {
 template <typename T>
 Vec2<T> operator /(const Vec2<T>& lhs, T rhs) {
     return Vec2<T>(lhs.x / rhs, lhs.y / rhs);
-}
-
-template <typename T>
-Vec2<T>& operator +=(Vec2<T>& lhs, const Vec2<T>& rhs) {
-    lhs.x += rhs.x;
-    lhs.y += rhs.y;
-    return lhs;
-}
-
-template <typename T>
-Vec2<T>& operator -=(Vec2<T>& lhs, const Vec2<T>& rhs) {
-    lhs.x -= rhs.x;
-    lhs.y -= rhs.y;
-    return lhs;
 }
 
 template <typename T>

--- a/src/xci/graphics/Primitives.cpp
+++ b/src/xci/graphics/Primitives.cpp
@@ -492,9 +492,8 @@ void Primitives::draw(View& view)
 
 void Primitives::draw(View& view, VariCoords pos)
 {
-    view.push_offset(view.to_fb(pos));
+    auto pop_offset = view.push_offset(view.to_fb(pos));
     draw(view);
-    view.pop_offset();
 }
 
 

--- a/src/xci/graphics/Primitives.cpp
+++ b/src/xci/graphics/Primitives.cpp
@@ -1,7 +1,7 @@
 // Primitives.cpp created on 2018-08-03 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Primitives.h"
@@ -283,7 +283,7 @@ void Primitives::end_primitive()
 }
 
 
-void Primitives::add_vertex(ViewportCoords xy, float u, float v)
+void Primitives::add_vertex(FramebufferCoords xy, float u, float v)
 {
     assert(m_format == VertexFormat::V2t2);
     assert(m_open_vertices != -1);
@@ -295,7 +295,7 @@ void Primitives::add_vertex(ViewportCoords xy, float u, float v)
 }
 
 
-void Primitives::add_vertex(ViewportCoords xy, float u1, float v1, float u2, float v2)
+void Primitives::add_vertex(FramebufferCoords xy, float u1, float v1, float u2, float v2)
 {
     assert(m_format == VertexFormat::V2t22);
     assert(m_open_vertices != -1);
@@ -309,7 +309,7 @@ void Primitives::add_vertex(ViewportCoords xy, float u1, float v1, float u2, flo
 }
 
 
-void Primitives::add_vertex(ViewportCoords xy, Color color, float u, float v)
+void Primitives::add_vertex(FramebufferCoords xy, Color color, float u, float v)
 {
     assert(m_format == VertexFormat::V2c4t2);
     assert(m_open_vertices != -1);
@@ -326,7 +326,7 @@ void Primitives::add_vertex(ViewportCoords xy, Color color, float u, float v)
 
 
 void
-Primitives::add_vertex(ViewportCoords xy, Color color, float u1, float v1, float u2, float v2)
+Primitives::add_vertex(FramebufferCoords xy, Color color, float u1, float v1, float u2, float v2)
 {
     assert(m_format == VertexFormat::V2c4t22);
     assert(m_open_vertices != -1);
@@ -352,8 +352,6 @@ void Primitives::clear()
     clear_uniforms();
     m_closed_vertices = 0;
     m_open_vertices = -1;
-    m_texture.ptr = nullptr;
-    m_blend = BlendFunc::Off;
 }
 
 
@@ -467,7 +465,7 @@ void Primitives::draw(View& view)
             .extent = { INT32_MAX, INT32_MAX },
     };
     if (view.has_crop()) {
-        auto cr = view.rect_to_framebuffer(view.get_crop());
+        auto cr = view.get_crop().moved(view.framebuffer_origin());
         scissor.offset.x = cr.x.as<int32_t>();
         scissor.offset.y = cr.y.as<int32_t>();
         scissor.extent.width = cr.w.as<int32_t>();
@@ -492,9 +490,9 @@ void Primitives::draw(View& view)
 }
 
 
-void Primitives::draw(View& view, const ViewportCoords& pos)
+void Primitives::draw(View& view, VariCoords pos)
 {
-    view.push_offset(pos);
+    view.push_offset(view.to_fb(pos));
     draw(view);
     view.pop_offset();
 }

--- a/src/xci/graphics/Primitives.h
+++ b/src/xci/graphics/Primitives.h
@@ -1,7 +1,7 @@
 // Primitives.h created on 2018-04-08 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_GRAPHICS_PRIMITIVES_H
@@ -119,10 +119,10 @@ public:
 
     void begin_primitive();
     void end_primitive();
-    void add_vertex(ViewportCoords xy, float u, float v);
-    void add_vertex(ViewportCoords xy, float u1, float v1, float u2, float v2);
-    void add_vertex(ViewportCoords xy, Color color, float u, float v);
-    void add_vertex(ViewportCoords xy, Color color, float u1, float v1, float u2, float v2);
+    void add_vertex(FramebufferCoords xy, float u, float v);
+    void add_vertex(FramebufferCoords xy, float u1, float v1, float u2, float v2);
+    void add_vertex(FramebufferCoords xy, Color color, float u, float v);
+    void add_vertex(FramebufferCoords xy, Color color, float u1, float v1, float u2, float v2);
     void clear();
     bool empty() const { return m_vertex_data.empty(); }
 
@@ -141,7 +141,7 @@ public:
 
     void update();
     void draw(View& view);
-    void draw(View& view, const ViewportCoords& pos);
+    void draw(View& view, VariCoords pos);
 
 private:
     void update_pipeline();

--- a/src/xci/graphics/Shape.cpp
+++ b/src/xci/graphics/Shape.cpp
@@ -234,4 +234,14 @@ void Shape::draw(View& view, VariCoords pos)
 }
 
 
+// -----------------------------------------------------------------------------
+
+
+ShapeBuilder& ShapeBuilder::add_ellipse(const VariRect& rect, VariUnits outline_thickness)
+{
+    m_shape.add_ellipse(m_view.to_fb(rect), m_view.to_fb(outline_thickness));
+    return *this;
+}
+
+
 } // namespace xci::graphics

--- a/src/xci/graphics/Shape.cpp
+++ b/src/xci/graphics/Shape.cpp
@@ -237,9 +237,44 @@ void Shape::draw(View& view, VariCoords pos)
 // -----------------------------------------------------------------------------
 
 
+ShapeBuilder& ShapeBuilder::add_line_slice(const VariRect& slice, VariCoords a, VariCoords b, VariUnits thickness)
+{
+    m_shape.add_line_slice(m_view.to_fb(slice), m_view.to_fb(a), m_view.to_fb(b), m_view.to_fb(thickness));
+    return *this;
+}
+
+
+ShapeBuilder& ShapeBuilder::add_rectangle(const VariRect& rect, VariUnits outline_thickness)
+{
+    m_shape.add_rectangle(m_view.to_fb(rect), m_view.to_fb(outline_thickness));
+    return *this;
+}
+
+
+ShapeBuilder& ShapeBuilder::add_rectangle_slice(const VariRect& slice, const VariRect& rect, VariUnits outline_thickness)
+{
+    m_shape.add_rectangle_slice(m_view.to_fb(slice), m_view.to_fb(rect), m_view.to_fb(outline_thickness));
+    return *this;
+}
+
+
 ShapeBuilder& ShapeBuilder::add_ellipse(const VariRect& rect, VariUnits outline_thickness)
 {
     m_shape.add_ellipse(m_view.to_fb(rect), m_view.to_fb(outline_thickness));
+    return *this;
+}
+
+
+ShapeBuilder& ShapeBuilder::add_ellipse_slice(const VariRect& slice, const VariRect& ellipse, VariUnits outline_thickness)
+{
+    m_shape.add_ellipse_slice(m_view.to_fb(slice), m_view.to_fb(ellipse), m_view.to_fb(outline_thickness));
+    return *this;
+}
+
+
+ShapeBuilder& ShapeBuilder::add_rounded_rectangle(const VariRect& rect, VariUnits radius, VariUnits outline_thickness)
+{
+    m_shape.add_rounded_rectangle(m_view.to_fb(rect), m_view.to_fb(radius), m_view.to_fb(outline_thickness));
     return *this;
 }
 

--- a/src/xci/graphics/Shape.cpp
+++ b/src/xci/graphics/Shape.cpp
@@ -1,7 +1,7 @@
 // Shape.cpp created on 2018-04-04 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Shape.h"
@@ -22,9 +22,9 @@ Shape::Shape(Renderer& renderer, Color fill_color, Color outline_color)
 {}
 
 
-void Shape::add_line_slice(const ViewportRect& slice,
-                           const ViewportCoords& a, const ViewportCoords& b,
-                           ViewportUnits thickness)
+void Shape::add_line_slice(const FramebufferRect& slice,
+                           FramebufferCoords a, FramebufferCoords b,
+                           FramebufferPixels thickness)
 {
     auto dir = (b-a).norm();
     auto rotate = [dir](float x, float y) -> Vec2f {
@@ -54,7 +54,7 @@ void Shape::add_line_slice(const ViewportRect& slice,
 }
 
 
-void Shape::add_rectangle(const ViewportRect& rect, ViewportUnits outline_thickness)
+void Shape::add_rectangle(const FramebufferRect& rect, FramebufferPixels outline_thickness)
 {
     auto x1 = rect.x;
     auto y1 = rect.y;
@@ -74,8 +74,8 @@ void Shape::add_rectangle(const ViewportRect& rect, ViewportUnits outline_thickn
 }
 
 
-void Shape::add_rectangle_slice(const ViewportRect& slice, const ViewportRect& rect,
-                                ViewportUnits outline_thickness)
+void Shape::add_rectangle_slice(const FramebufferRect& slice, const FramebufferRect& rect,
+                                FramebufferPixels outline_thickness)
 {
     auto x1 = slice.x;
     auto y1 = slice.y;
@@ -102,7 +102,7 @@ void Shape::add_rectangle_slice(const ViewportRect& slice, const ViewportRect& r
 }
 
 
-void Shape::add_ellipse(const ViewportRect& rect, ViewportUnits outline_thickness)
+void Shape::add_ellipse(const FramebufferRect& rect, FramebufferPixels outline_thickness)
 {
     auto x1 = rect.x;
     auto y1 = rect.y;
@@ -121,8 +121,8 @@ void Shape::add_ellipse(const ViewportRect& rect, ViewportUnits outline_thicknes
 }
 
 
-void Shape::add_ellipse_slice(const ViewportRect& slice, const ViewportRect& ellipse,
-                              ViewportUnits outline_thickness)
+void Shape::add_ellipse_slice(const FramebufferRect& slice, const FramebufferRect& ellipse,
+                              FramebufferPixels outline_thickness)
 {
     auto x1 = slice.x;
     auto y1 = slice.y;
@@ -148,8 +148,8 @@ void Shape::add_ellipse_slice(const ViewportRect& slice, const ViewportRect& ell
 
 
 void
-Shape::add_rounded_rectangle(const ViewportRect& rect, ViewportUnits radius,
-                             ViewportUnits outline_thickness)
+Shape::add_rounded_rectangle(const FramebufferRect& rect, FramebufferPixels radius,
+                             FramebufferPixels outline_thickness)
 {
     // the shape is composed from 7-slice pattern:
     // corner ellipse slices and center rectangle slices
@@ -218,7 +218,7 @@ void Shape::update()
 }
 
 
-void Shape::draw(View& view, const ViewportCoords& pos)
+void Shape::draw(View& view, VariCoords pos)
 {
     // lines
     if (!m_lines.empty())

--- a/src/xci/graphics/Shape.h
+++ b/src/xci/graphics/Shape.h
@@ -85,7 +85,7 @@ public:
     void update();
 
     // Draw all shapes to `view` at `pos`.
-    // Final shape position is `pos` + shapes's relative position
+    // Final shape position is `pos` + shapes' relative position
     void draw(View& view, VariCoords pos);
 
 private:
@@ -103,6 +103,19 @@ private:
     Shader& m_ellipse_shader;
 };
 
+
+/// Convenience - build shapes in resize() method with any units
+class ShapeBuilder {
+public:
+    ShapeBuilder(View& view, Shape& shape) : m_view(view), m_shape(shape) { m_shape.clear(); }
+    ~ShapeBuilder() { m_shape.update(); }
+
+    ShapeBuilder& add_ellipse(const VariRect& rect, VariUnits outline_thickness = {});
+
+private:
+    View& m_view;
+    Shape& m_shape;
+};
 
 } // namespace xci::graphics
 

--- a/src/xci/graphics/Shape.h
+++ b/src/xci/graphics/Shape.h
@@ -110,7 +110,12 @@ public:
     ShapeBuilder(View& view, Shape& shape) : m_view(view), m_shape(shape) { m_shape.clear(); }
     ~ShapeBuilder() { m_shape.update(); }
 
+    ShapeBuilder& add_line_slice(const VariRect& slice, VariCoords a, VariCoords b, VariUnits thickness);
+    ShapeBuilder& add_rectangle(const VariRect& rect, VariUnits outline_thickness = {});
+    ShapeBuilder& add_rectangle_slice(const VariRect& slice, const VariRect& rect, VariUnits outline_thickness = {});
     ShapeBuilder& add_ellipse(const VariRect& rect, VariUnits outline_thickness = {});
+    ShapeBuilder& add_ellipse_slice(const VariRect& slice, const VariRect& ellipse, VariUnits outline_thickness = {});
+    ShapeBuilder& add_rounded_rectangle(const VariRect& rect, VariUnits radius, VariUnits outline_thickness = {});
 
 private:
     View& m_view;

--- a/src/xci/graphics/Shape.h
+++ b/src/xci/graphics/Shape.h
@@ -1,7 +1,7 @@
 // Shape.h created on 2018-04-04 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_GRAPHICS_SHAPES_H
@@ -45,35 +45,35 @@ public:
     //   ---- a --- b ----
     //                    > thickness
     //   -----------------
-    void add_line_slice(const ViewportRect& slice,
-                        const ViewportCoords& a, const ViewportCoords& b,
-                        ViewportUnits thickness);
+    void add_line_slice(const FramebufferRect& slice,
+                        FramebufferCoords a, FramebufferCoords b,
+                        FramebufferPixels thickness);
 
     // Add new rectangle.
     // `rect`              - rectangle position and size
     // `outline_thickness` - the outline actually goes from edge to inside
-    //                       this parameter defines how far (in viewport units)
-    void add_rectangle(const ViewportRect& rect,
-                       ViewportUnits outline_thickness = 0);
-    void add_rectangle_slice(const ViewportRect& slice, const ViewportRect& rect,
-                             ViewportUnits outline_thickness = 0);
+    //                       this parameter defines how far (in framebuffer pixels)
+    void add_rectangle(const FramebufferRect& rect,
+                       FramebufferPixels outline_thickness = 0);
+    void add_rectangle_slice(const FramebufferRect& slice, const FramebufferRect& rect,
+                             FramebufferPixels outline_thickness = 0);
 
     // Add new ellipse.
     // `rect`              - ellipse position and size
     // `outline_thickness` - the outline actually goes from edge to inside
-    //                       this parameter defines how far (in display units)
-    void add_ellipse(const ViewportRect& rect,
-                     ViewportUnits outline_thickness = 0);
-    void add_ellipse_slice(const ViewportRect& slice, const ViewportRect& ellipse,
-                           ViewportUnits outline_thickness = 0);
+    //                       this parameter defines how far (in framebuffer pixels)
+    void add_ellipse(const FramebufferRect& rect,
+                     FramebufferPixels outline_thickness = 0);
+    void add_ellipse_slice(const FramebufferRect& slice, const FramebufferRect& ellipse,
+                           FramebufferPixels outline_thickness = 0);
 
     // Add new rounded rectangle.
     // `rect`              - position and size
     // `radius`            - corner radius
     // `outline_thickness` - the outline actually goes from edge to inside
     //                       this parameter defines how far (in display units)
-    void add_rounded_rectangle(const ViewportRect& rect, ViewportUnits radius,
-                               ViewportUnits outline_thickness = 0);
+    void add_rounded_rectangle(const FramebufferRect& rect, FramebufferPixels radius,
+                               FramebufferPixels outline_thickness = 0);
 
     // Reserve memory for a number of `lines`, `rectangles`, `ellipses`.
     void reserve(size_t lines, size_t rectangles, size_t ellipses);
@@ -86,7 +86,7 @@ public:
 
     // Draw all shapes to `view` at `pos`.
     // Final shape position is `pos` + shapes's relative position
-    void draw(View& view, const ViewportCoords& pos);
+    void draw(View& view, VariCoords pos);
 
 private:
     Color m_fill_color;

--- a/src/xci/graphics/Sprites.cpp
+++ b/src/xci/graphics/Sprites.cpp
@@ -1,7 +1,7 @@
 // Sprites.cpp created on 2018-03-14 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Sprites.h"
@@ -26,7 +26,7 @@ void Sprites::reserve(size_t num)
 }
 
 
-void Sprites::add_sprite(const ViewportRect& rect)
+void Sprites::add_sprite(const FramebufferRect& rect)
 {
     auto ts = m_texture.size();
     add_sprite(rect, {0, 0, ts.x, ts.y});
@@ -34,7 +34,7 @@ void Sprites::add_sprite(const ViewportRect& rect)
 
 
 // Position a sprite with cutoff from the texture
-void Sprites::add_sprite(const ViewportRect& rect, const Rect_u& texrect)
+void Sprites::add_sprite(const FramebufferRect& rect, const Rect_u& texrect)
 {
     auto x1 = rect.x;
     auto y1 = rect.y;
@@ -65,7 +65,7 @@ void Sprites::update()
 }
 
 
-void Sprites::draw(View& view, const ViewportCoords& pos)
+void Sprites::draw(View& view, VariCoords pos)
 {
     m_quads.draw(view, pos);
 }
@@ -88,7 +88,7 @@ void ColoredSprites::reserve(size_t num)
 }
 
 
-void ColoredSprites::add_sprite(const ViewportRect& rect)
+void ColoredSprites::add_sprite(const FramebufferRect& rect)
 {
     auto ts = m_texture.size();
     add_sprite(rect, {0, 0, ts.x, ts.y});
@@ -96,7 +96,7 @@ void ColoredSprites::add_sprite(const ViewportRect& rect)
 
 
 // Position a sprite with cutoff from the texture
-void ColoredSprites::add_sprite(const ViewportRect& rect, const Rect_u& texrect)
+void ColoredSprites::add_sprite(const FramebufferRect& rect, const Rect_u& texrect)
 {
     auto x1 = rect.x;
     auto y1 = rect.y;
@@ -126,7 +126,7 @@ void ColoredSprites::update()
 }
 
 
-void ColoredSprites::draw(View& view, const ViewportCoords& pos)
+void ColoredSprites::draw(View& view, VariCoords pos)
 {
     m_quads.draw(view, pos);
 }

--- a/src/xci/graphics/Sprites.h
+++ b/src/xci/graphics/Sprites.h
@@ -1,7 +1,7 @@
 // Sprites.h created on 2018-03-04 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_GRAPHICS_SPRITES_H
@@ -37,18 +37,18 @@ public:
 
     // Add new sprite containing whole texture
     // `rect` defines position and size of the sprite
-    void add_sprite(const ViewportRect& rect);
+    void add_sprite(const FramebufferRect& rect);
 
     // Add new sprite containing a cutoff from the texture
     // `rect` defines position and size of the sprite
-    void add_sprite(const ViewportRect& rect, const Rect_u& texrect);
+    void add_sprite(const FramebufferRect& rect, const Rect_u& texrect);
 
     // Update sprites attributes according to settings (color etc.)
     void update();
 
     // Draw all sprites to `view` at `pos`.
     // Final sprite position is `pos` + sprite's relative position
-    void draw(View& view, const ViewportCoords& pos);
+    void draw(View& view, VariCoords pos);
 
 private:
     Texture& m_texture;
@@ -74,18 +74,18 @@ public:
 
     // Add new sprite containing whole texture
     // `rect` defines position and size of the sprite
-    void add_sprite(const ViewportRect& rect);
+    void add_sprite(const FramebufferRect& rect);
 
     // Add new sprite containing a cutoff from the texture
     // `rect` defines position and size of the sprite
-    void add_sprite(const ViewportRect& rect, const Rect_u& texrect);
+    void add_sprite(const FramebufferRect& rect, const Rect_u& texrect);
 
     // Update sprites attributes according to settings (color etc.)
     void update();
 
     // Draw all sprites to `view` at `pos`.
     // Final sprite position is `pos` + sprite's relative position
-    void draw(View& view, const ViewportCoords& pos);
+    void draw(View& view, VariCoords pos);
 
 private:
     Texture& m_texture;

--- a/src/xci/graphics/View.cpp
+++ b/src/xci/graphics/View.cpp
@@ -176,9 +176,10 @@ ViewportCoords View::viewport_center() const
 }
 
 
-void View::push_offset(VariCoords offset)
+auto View::push_offset(VariCoords offset) -> PopHelper<FramebufferCoords>
 {
     m_offset.push_back(this->offset() + to_fb(offset));
+    return {m_offset};
 }
 
 
@@ -190,13 +191,14 @@ FramebufferCoords View::offset() const
 }
 
 
-void View::push_crop(const FramebufferRect& region)
+auto View::push_crop(const FramebufferRect& region) -> PopHelper<FramebufferRect>
 {
     if (m_crop.empty())
         m_crop.push_back(region.moved(offset()));
     else {
         m_crop.push_back(region.moved(offset()).intersection(m_crop.back()));
     }
+    return {m_crop};
 }
 
 

--- a/src/xci/graphics/View.cpp
+++ b/src/xci/graphics/View.cpp
@@ -11,6 +11,62 @@
 namespace xci::graphics {
 
 
+VariUnits::Type VariUnits::type() const
+{
+    // three upper bits, complemented in case of negative value (sign bit = 0)
+    switch ( (m_storage < 0 ? ~m_storage : m_storage) >> 29 ) {
+        case 0b00:  return Framebuffer;
+        case 0b01:  return Screen;
+        default:    return Viewport;
+    }
+}
+
+
+FramebufferPixels VariUnits::framebuffer() const
+{
+    assert(type() == Framebuffer);
+    return { float(m_storage) / float(1<<10) };
+}
+
+
+ScreenPixels VariUnits::screen() const
+{
+    assert(type() == Screen);
+    return { float(m_storage ^ 0x20000000) / float(1<<10) };
+}
+
+
+ViewportUnits VariUnits::viewport() const
+{
+    assert(type() == Viewport);
+    return { float(m_storage ^ 0x40000000) / float(1<<26) };
+}
+
+
+int32_t VariUnits::to_storage(FramebufferPixels fb)
+{
+    const auto r = int32_t(fb.value * double(1<<10));
+    assert((r < 0 ? ~r : r) >> 29 == 0);
+    return r;
+}
+
+
+int32_t VariUnits::to_storage(ScreenPixels px)
+{
+    const auto r = int32_t(px.value * float(1<<10));
+    assert((r < 0 ? ~r : r) >> 29 == 0);
+    return r ^ 0x20000000;
+}
+
+
+int32_t VariUnits::to_storage(ViewportUnits vp)
+{
+    const auto r = int32_t(vp.value * float(1<<26));
+    assert((r < 0 ? ~r : r) >> 30 == 0);
+    return r ^ 0x40000000;
+}
+
+
 std::array<float, 16> View::projection_matrix() const
 {
     float xs = 2.0f / viewport_size().x.value;

--- a/src/xci/graphics/View.cpp
+++ b/src/xci/graphics/View.cpp
@@ -164,6 +164,13 @@ FramebufferCoords View::framebuffer_origin() const
 }
 
 
+void View::set_viewport_scale(float scale)
+{
+    m_vp_scale = scale;
+    rescale_viewport();
+}
+
+
 ViewportCoords View::viewport_center() const
 {
     if (m_origin == ViewOrigin::TopLeft) {

--- a/src/xci/graphics/View.h
+++ b/src/xci/graphics/View.h
@@ -189,7 +189,19 @@ public:
     /// In reverse, subtract from reported (e.g. mouse) underlying coords to translate them to view.
     FramebufferCoords framebuffer_origin() const;
 
+    /// The viewport units are based on smaller viewport dimension.
+    /// One unit is by default 1% of the viewport. The default scale is 100.
+    /// Using this method, the scale can be changed to dynamically enlarge/shrink
+    /// the whole UI, when it's based on the viewport units.
+    void set_viewport_scale(float scale);
+    float viewport_scale() const { return m_vp_scale; }
+
+    /// Viewport size in viewport units.
+    /// E.g: {133.33, 100.0} for 800x600 (4/3 aspect ratio)
     ViewportSize viewport_size() const { return m_viewport_size; }
+
+    /// Coordinates of viewport center in viewport units.
+    /// By default {0, 0}. With TopLeft origin, it will be e.g. {66.66, 50}
     ViewportCoords viewport_center() const;
 
     // Convert units to framebuffer / screen:
@@ -405,7 +417,7 @@ private:
     ScreenSize m_screen_size;           // eg. {800, 600}
     FramebufferSize m_framebuffer_size; // eg. {1600, 1200}
     ViewOrigin m_origin = ViewOrigin::Center;
-    static constexpr float m_vp_scale = 100.0f;
+    float m_vp_scale = 100.0f;
     DebugFlags m_debug = 0;
     bool m_needs_refresh = true;  // start with dirty state to force first refresh
     std::vector<FramebufferRect> m_crop;  // Crop region stack (current crop region on back)

--- a/src/xci/graphics/View.h
+++ b/src/xci/graphics/View.h
@@ -96,7 +96,7 @@ constexpr ViewportUnits operator ""_vp (unsigned long long value) { return {floa
 ///                  - the value is fixed point decimal in 19 dot 10 bits format (+ 1 bit sign)
 /// ViewportUnits    - encoded in range -2147483648 .. 2147483647 (two upper bits are 01 or 10)
 ///                  - xor 0x40000000 to decode original value (30 bits + sign)
-///                  - the value is fixed point decimal in 4 dot 26 bits format (+ 1 bit sign)
+///                  - the value is fixed point decimal in 14 dot 16 bits format (+ 1 bit sign)
 class VariUnits {
 public:
     VariUnits() = default;
@@ -162,6 +162,11 @@ public:
     // ------------------------------------------------------------------------
     // Sizes, coordinates
 
+    /// Set origin of the coordinates (0,0).
+    /// This affects all units (framebuffer, screen, viewport).
+    /// Default: Center
+    void set_origin(ViewOrigin origin);
+
     // Size of the view in screen pixels. This size might be different
     // from framebuffer size - in that case, call also `set_framebuffer_size`.
     bool set_screen_size(ScreenSize size);
@@ -184,13 +189,6 @@ public:
     /// In reverse, subtract from reported (e.g. mouse) underlying coords to translate them to view.
     FramebufferCoords framebuffer_origin() const;
 
-    // Size of the view in "viewport" units. These units are used
-    // for placing objects in the view. Default view size is at least 2 units
-    // in either direction, with center at {0, 0} and aspect correction.
-    // X goes right, Y goes down. Total size in one of the dimensions
-    // will always equal 2.0.
-    // Eg: {2.666, 2.0} for 800x600 (4/3 aspect ratio)
-    void set_viewport_mode(ViewOrigin origin, float scale = 2.0f);
     ViewportSize viewport_size() const { return m_viewport_size; }
     ViewportCoords viewport_center() const;
 
@@ -407,7 +405,7 @@ private:
     ScreenSize m_screen_size;           // eg. {800, 600}
     FramebufferSize m_framebuffer_size; // eg. {1600, 1200}
     ViewOrigin m_origin = ViewOrigin::Center;
-    float m_scale = 2.0f;
+    static constexpr float m_vp_scale = 100.0f;
     DebugFlags m_debug = 0;
     bool m_needs_refresh = true;  // start with dirty state to force first refresh
     std::vector<FramebufferRect> m_crop;  // Crop region stack (current crop region on back)

--- a/src/xci/graphics/View.h
+++ b/src/xci/graphics/View.h
@@ -343,15 +343,22 @@ public:
     // ------------------------------------------------------------------------
     // Local offset of coordinates
 
-    void push_offset(VariCoords offset);
-    void pop_offset() { m_offset.pop_back(); }
+    template <class T>
+    class PopHelper {
+        friend View;
+        std::vector<T>& container;
+        PopHelper(std::vector<T>& c) : container(c) {}
+    public:
+        ~PopHelper() { container.pop_back(); }
+    };
+
+    PopHelper<FramebufferCoords> push_offset(VariCoords offset);
     FramebufferCoords offset() const;
 
     // ------------------------------------------------------------------------
     // Crop region (scissors test)
 
-    void push_crop(const FramebufferRect& region);
-    void pop_crop() { m_crop.pop_back(); }
+    PopHelper<FramebufferRect> push_crop(const FramebufferRect& region);
     bool has_crop() const { return !m_crop.empty(); }
     const FramebufferRect& get_crop() const { return m_crop.back(); }
 

--- a/src/xci/graphics/Window.cpp
+++ b/src/xci/graphics/Window.cpp
@@ -189,9 +189,9 @@ void Window::set_refresh_timeout(std::chrono::microseconds timeout,
 }
 
 
-void Window::set_view_mode(ViewOrigin origin, float scale)
+void Window::set_view_origin(ViewOrigin origin)
 {
-    m_view.set_viewport_mode(origin, scale);
+    m_view.set_origin(origin);
 }
 
 

--- a/src/xci/graphics/Window.cpp
+++ b/src/xci/graphics/Window.cpp
@@ -1,7 +1,7 @@
 // Window.cpp created on 2019-10-22 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2019–2021 Radek Brich
+// Copyright 2019–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Window.h"
@@ -144,7 +144,7 @@ void Window::set_mouse_position_callback(Window::MousePosCallback mpos_cb)
     glfwSetCursorPosCallback(m_window, [](GLFWwindow* window, double xpos, double ypos) {
         auto self = (Window*) glfwGetWindowUserPointer(window);
         if (self->m_mpos_cb) {
-            auto pos = self->m_view.coords_to_viewport(ScreenCoords{float(xpos), float(ypos)});
+            auto pos = self->m_view.px_to_fb(ScreenCoords{float(xpos), float(ypos)}) - self->m_view.framebuffer_origin();
             self->m_mpos_cb(self->m_view, MousePosEvent{pos});
         }
     });
@@ -159,7 +159,7 @@ void Window::set_mouse_button_callback(Window::MouseBtnCallback mbtn_cb)
         if (self->m_mbtn_cb) {
             double xpos, ypos;
             glfwGetCursorPos(window, &xpos, &ypos);
-            auto pos = self->m_view.coords_to_viewport(ScreenCoords{float(xpos), float(ypos)});
+            auto pos = self->m_view.px_to_fb(ScreenCoords{float(xpos), float(ypos)}) - self->m_view.framebuffer_origin();
             self->m_mbtn_cb(self->m_view, MouseBtnEvent{(MouseButton) button, (Action) action, pos});
         }
     });
@@ -189,7 +189,7 @@ void Window::set_refresh_timeout(std::chrono::microseconds timeout,
 }
 
 
-void Window::set_view_mode(ViewOrigin origin, ViewScale scale)
+void Window::set_view_mode(ViewOrigin origin, float scale)
 {
     m_view.set_viewport_mode(origin, scale);
 }

--- a/src/xci/graphics/Window.h
+++ b/src/xci/graphics/Window.h
@@ -223,11 +223,10 @@ public:
     ///                     True = periodic (no clear).
     void set_refresh_timeout(std::chrono::microseconds timeout, bool periodic);
 
-    /// Select kind of viewport units to be used throughout the program
-    /// for all placing and sizes of elements in view.
+    /// Set origin of the coordinates to be used throughout the program
+    /// for all placing elements in the view.
     /// \param origin       The position of (0,0) coordinates. Default is Center.
-    /// \param scale        The scale of the viewport units. Default is 2.0.
-    void set_view_mode(ViewOrigin origin, float scale = 2.0f);
+    void set_view_origin(ViewOrigin origin);
 
     void set_debug_flags(View::DebugFlags flags);
 

--- a/src/xci/graphics/Window.h
+++ b/src/xci/graphics/Window.h
@@ -1,7 +1,7 @@
 // Window.h created on 2018-03-04 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_GRAPHICS_WINDOW_H
@@ -121,13 +121,13 @@ struct CharEvent {
 enum class MouseButton { Left = 0, Right = 1, Middle = 2 };
 
 struct MousePosEvent {
-    ViewportCoords pos;
+    FramebufferCoords pos;
 };
 
 struct MouseBtnEvent {
     MouseButton button;
     Action action;
-    ViewportCoords pos;
+    FramebufferCoords pos;
 };
 
 
@@ -225,8 +225,8 @@ public:
     /// Select kind of viewport units to be used throughout the program
     /// for all placing and sizes of elements in view.
     /// \param origin       The position of (0,0) coordinates. Default is Center.
-    /// \param scale        The scale of the units. Default is ScalingWithAspectCorrection.
-    void set_view_mode(ViewOrigin origin, ViewScale scale);
+    /// \param scale        The scale of the viewport units. Default is 2.0.
+    void set_view_mode(ViewOrigin origin, float scale = 2.0f);
 
     void set_debug_flags(View::DebugFlags flags);
 

--- a/src/xci/graphics/Window.h
+++ b/src/xci/graphics/Window.h
@@ -212,6 +212,7 @@ public:
     // - OnEvent is similar, but does not require explicit calls to View::refresh()
     // - Periodic is good for games (continuous animations)
     void set_refresh_mode(RefreshMode mode)  { m_refresh_mode = mode; }
+    RefreshMode refresh_mode() const { return m_refresh_mode; }
 
     /// Set refresh timeout. This is useful for OnDemand/OnEvent modes,
     /// where no update events are generated unless an event occurs.

--- a/src/xci/text/Layout.cpp
+++ b/src/xci/text/Layout.cpp
@@ -125,7 +125,7 @@ void Layout::update(const graphics::View& target)
     // setup debug rectangles
 
     auto& renderer = target.window()->renderer();
-    const auto sc_1px = target.size_to_viewport(1_sc);
+    const auto sc_1px = target.size_to_viewport(1_px);
     m_debug_shapes.clear();
 
     // Debug: page bbox

--- a/src/xci/text/Layout.cpp
+++ b/src/xci/text/Layout.cpp
@@ -1,7 +1,7 @@
 // Layout.cpp created on 2018-03-10 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Layout.h"
@@ -26,7 +26,7 @@ void Layout::clear()
 }
 
 
-void Layout::set_default_page_width(ViewportUnits width)
+void Layout::set_default_page_width(VariUnits width)
 {
     m_default_width = width;
     m_page.clear();
@@ -40,7 +40,7 @@ void Layout::set_default_font(Font* font)
 }
 
 
-void Layout::set_default_font_size(ViewportUnits size, bool allow_scale)
+void Layout::set_default_font_size(VariUnits size, bool allow_scale)
 {
     m_default_style.set_size(size);
     m_default_style.set_allow_scale(allow_scale);
@@ -69,7 +69,7 @@ void Layout::set_default_color(graphics::Color color)
 }
 
 
-void Layout::set_default_outline_radius(ViewportUnits radius)
+void Layout::set_default_outline_radius(VariUnits radius)
 {
     m_default_style.set_outline_radius(radius);
     m_page.clear();
@@ -83,9 +83,8 @@ void Layout::set_default_outline_color(graphics::Color color)
 }
 
 
-void Layout::set_default_tab_stops(std::vector<ViewportUnits> stops)
+void Layout::set_default_tab_stops(std::vector<VariUnits> stops)
 {
-    std::sort(stops.begin(), stops.end());
     m_default_tab_stops = std::move(stops);
     m_page.clear();
 }
@@ -98,17 +97,17 @@ void Layout::set_default_alignment(Alignment alignment)
 }
 
 
-void Layout::typeset(const graphics::View& target)
+void Layout::typeset(const View& target)
 {
     m_page.clear();
     m_page.set_target(&target);
-    m_page.set_width(m_default_width);
+    m_page.set_width(target.to_fb(m_default_width));
     m_page.set_style(m_default_style);
     m_page.set_alignment(m_default_alignment);
 
     m_page.reset_tab_stops();
     for (auto stop : m_default_tab_stops)
-        m_page.add_tab_stop(stop);
+        m_page.add_tab_stop(target.to_fb((stop)));
 
     for (auto& elem : m_elements) {
         elem->apply(m_page);
@@ -116,7 +115,7 @@ void Layout::typeset(const graphics::View& target)
     m_page.finish_line();
 }
 
-void Layout::update(const graphics::View& target)
+void Layout::update(const View& target)
 {
     m_page.foreach_word([&](Word& word) {
         word.update(target);
@@ -125,7 +124,7 @@ void Layout::update(const graphics::View& target)
     // setup debug rectangles
 
     auto& renderer = target.window()->renderer();
-    const auto sc_1px = target.size_to_viewport(1_px);
+    const auto fb_1px = target.px_to_fb(1_px);
     m_debug_shapes.clear();
 
     // Debug: page bbox
@@ -133,7 +132,7 @@ void Layout::update(const graphics::View& target)
         m_debug_shapes.emplace_back(renderer,
                 Color(150, 150, 0, 128),
                 Color(200, 200, 50));
-        m_debug_shapes.back().add_rectangle(bbox(), sc_1px);
+        m_debug_shapes.back().add_rectangle(bbox(), fb_1px);
         m_debug_shapes.back().update();
     }
 
@@ -144,7 +143,7 @@ void Layout::update(const graphics::View& target)
                 Color(200, 50, 250));
         m_page.foreach_span([&](const Span& span) {
             for (const auto& part : span.parts()) {
-                m_debug_shapes.back().add_rectangle(part.bbox(), sc_1px);
+                m_debug_shapes.back().add_rectangle(part.bbox(), fb_1px);
             }
         });
         m_debug_shapes.back().update();
@@ -156,7 +155,7 @@ void Layout::update(const graphics::View& target)
                 Color(0, 50, 150, 128),
                 Color(50, 50, 250));
         m_page.foreach_line([&](const Line& line) {
-            m_debug_shapes.back().add_rectangle(line.bbox(), sc_1px);
+            m_debug_shapes.back().add_rectangle(line.bbox(), fb_1px);
         });
         m_debug_shapes.back().update();
     }
@@ -167,7 +166,7 @@ void Layout::update(const graphics::View& target)
         m_page.foreach_line([&](const Line& line) {
             auto rect = line.bbox();
             rect.y += line.baseline();
-            rect.h = sc_1px;
+            rect.h = fb_1px;
             m_debug_shapes.back().add_rectangle(rect);
         });
         m_debug_shapes.back().update();
@@ -175,19 +174,19 @@ void Layout::update(const graphics::View& target)
 }
 
 
-void Layout::draw(View& target, const ViewportCoords& pos) const
+void Layout::draw(View& view, VariCoords pos) const
 {
     for (auto& shape : m_debug_shapes) {
-        shape.draw(target, pos);
+        shape.draw(view, pos);
     }
 
     m_page.foreach_word([&](const Word& word) {
-        word.draw(target, pos);
+        word.draw(view, view.to_fb(pos));
     });
 }
 
 
-void Layout::set_page_width(ViewportUnits width)
+void Layout::set_page_width(VariUnits width)
 {
     m_elements.push_back(std::make_unique<SetPageWidth>(width));
 }
@@ -199,7 +198,7 @@ void Layout::set_alignment(Alignment alignment)
 }
 
 
-void Layout::add_tab_stop(ViewportUnits x)
+void Layout::add_tab_stop(VariUnits x)
 {
     m_elements.push_back(std::make_unique<AddTabStop>(x));
 }
@@ -211,7 +210,7 @@ void Layout::reset_tab_stops()
 }
 
 
-void Layout::set_offset(const ViewportSize& offset)
+void Layout::set_offset(VariSize offset)
 {
     m_elements.push_back(std::make_unique<SetOffset>(offset));
 }
@@ -223,7 +222,7 @@ void Layout::set_font(Font* font)
 }
 
 
-void Layout::set_font_size(ViewportUnits size)
+void Layout::set_font_size(VariUnits size)
 {
     m_elements.push_back(std::make_unique<SetFontSize>(size));
 }
@@ -308,9 +307,9 @@ Span* Layout::get_span(const std::string& name)
 }
 
 
-ViewportRect Layout::bbox() const
+FramebufferRect Layout::bbox() const
 {
-    ViewportRect bbox;
+    FramebufferRect bbox;
     bool first = true;
     m_page.foreach_line([&](const Line& line) {
         if (first) {

--- a/src/xci/text/Layout.h
+++ b/src/xci/text/Layout.h
@@ -1,7 +1,7 @@
 // Layout.h created on 2018-03-10 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_TEXT_LAYOUT_H
@@ -25,6 +25,10 @@
 namespace xci::text {
 namespace layout {
 
+using graphics::VariUnits;
+using graphics::VariCoords;
+using graphics::Color;
+using graphics::View;
 
 // Layout allows to record a stream of elements (text and control)
 // and then apply this stream of elements to generate precise positions
@@ -36,15 +40,15 @@ public:
     void clear();
 
     // These are not affected by `clear`
-    void set_default_page_width(ViewportUnits width);
+    void set_default_page_width(VariUnits width);
     void set_default_font(Font* font);
-    void set_default_font_size(ViewportUnits size, bool allow_scale = true);
+    void set_default_font_size(VariUnits size, bool allow_scale = true);
     void set_default_font_style(FontStyle font_style);
     void set_default_font_weight(uint16_t weight);
-    void set_default_color(graphics::Color color);
-    void set_default_outline_radius(ViewportUnits radius);
-    void set_default_outline_color(graphics::Color color);
-    void set_default_tab_stops(std::vector<ViewportUnits> stops);
+    void set_default_color(Color color);
+    void set_default_outline_radius(VariUnits radius);
+    void set_default_outline_color(Color color);
+    void set_default_tab_stops(std::vector<VariUnits> stops);
     void set_default_alignment(Alignment alignment);
 
     const Style& default_style() const { return m_default_style; }
@@ -57,29 +61,29 @@ public:
 
     // Set page width. This drives the line breaking.
     // Default: 0 (same as INF - no line breaking)
-    void set_page_width(ViewportUnits width);
+    void set_page_width(VariUnits width);
 
     // Set text alignment
     void set_alignment(Alignment alignment);
 
     // Horizontal tab stops. Following Tab elements will add horizontal space
     // up to next tab stop.
-    void add_tab_stop(ViewportUnits x);
+    void add_tab_stop(VariUnits x);
     void reset_tab_stops();
 
     // Horizontal/vertical offset (in multiplies of font size)
     // This can be used to create subscript/superscript.
-    void set_offset(const ViewportSize& offset);
-    void reset_offset() { set_offset({0.f, 0.f}); }
+    void set_offset(VariSize offset);
+    void reset_offset() { set_offset({0_fb, 0_fb}); }
 
     // Set font and text style.
     // Also affects spacing (which depends on font metrics).
     void set_font(Font* font);
-    void set_font_size(ViewportUnits size);
+    void set_font_size(VariUnits size);
     void set_font_style(FontStyle font_style);
     void set_bold(bool bold = true);
     void set_italic(bool italic = true);
-    void set_color(graphics::Color color);
+    void set_color(Color color);
     void reset_color();
 
     // ------------------------------------------------------------------------
@@ -126,27 +130,27 @@ public:
     // Should be called on every change of framebuffer size
     // and after addition of new elements.
     // Use also to realign/reflow after changing width or alignment.
-    void typeset(const graphics::View& target);
+    void typeset(const View& target);
 
     // Recreate graphics objects. Must be called at least once before draw.
-    void update(const graphics::View& target);
+    void update(const View& target);
 
     // Draw whole layout to target
-    void draw(graphics::View& target, const ViewportCoords& pos) const;
+    void draw(View& view, VariCoords pos) const;
 
     // ------------------------------------------------------------------------
     // Metrics
 
-    ViewportRect bbox() const;
+    FramebufferRect bbox() const;
 
 private:
     Page m_page;
     std::vector<std::unique_ptr<Element>> m_elements;
 
     Style m_default_style;
-    ViewportUnits m_default_width = 0;
+    VariUnits m_default_width = 0_px;
     Alignment m_default_alignment = Alignment::Left;
-    std::vector<ViewportUnits> m_default_tab_stops;
+    std::vector<VariUnits> m_default_tab_stops;
 
     mutable core::ChunkedStack<graphics::Shape> m_debug_shapes;
 };

--- a/src/xci/text/Style.cpp
+++ b/src/xci/text/Style.cpp
@@ -16,8 +16,8 @@ using namespace graphics;
 void Style::clear()
 {
     m_font = nullptr;
-    m_size = 0.05_vp;
-    m_outline_radius = 0.0_vp;
+    m_size = 2.5_vp;
+    m_outline_radius = 0_fb;
     m_color = graphics::Color::White();
     m_outline_color = graphics::Color::Transparent();
     m_font_style = FontStyle::Regular;

--- a/src/xci/text/Style.cpp
+++ b/src/xci/text/Style.cpp
@@ -1,7 +1,7 @@
 // Style.cpp created on 2018-03-18 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Style.h"
@@ -33,7 +33,7 @@ void Style::apply_view(const View& view)
     if (m_font_weight != 0)
         m_font->set_weight(m_font_weight);
     // convert font size
-    auto font_size = view.size_to_framebuffer(m_size);
+    auto font_size = view.to_fb(m_size);
     m_font->set_size(unsigned(std::ceil(font_size.value)));
     m_scale = m_allow_scale ? font_size.value / m_font->height() : 1.0f;
     // two pass rendering - disable stroker for the first pass
@@ -45,7 +45,7 @@ void Style::apply_outline(const View& view)
 {
     m_font->set_stroke(
             m_color.is_transparent() ? StrokeType::Outline : StrokeType::OutsideBorder,
-            view.size_to_framebuffer(m_outline_radius).value);
+            view.to_fb(m_outline_radius).value);
 }
 
 

--- a/src/xci/text/Style.h
+++ b/src/xci/text/Style.h
@@ -1,7 +1,7 @@
 // Style.h created on 2018-03-18 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_TEXT_STYLE_H
@@ -13,7 +13,7 @@
 
 namespace xci::text {
 
-using graphics::ViewportUnits;
+using graphics::VariUnits;
 using namespace graphics::unit_literals;
 
 
@@ -33,8 +33,8 @@ public:
     Font* font() const { return m_font; }
 
     // Request font size
-    void set_size(ViewportUnits size) { m_size = size; }
-    ViewportUnits size() const { return m_size; }
+    void set_size(VariUnits size) { m_size = size; }
+    VariUnits size() const { return m_size; }
 
     // Set false to force using exact font size, without GPU scaling
     void set_allow_scale(bool allow_scale) { m_allow_scale = allow_scale; }
@@ -56,8 +56,8 @@ public:
     // * outline color other than Transparent enables the outline
     // * set Transparent text color to get outlined text without inner filling
     // * set both colors to get a text with colored outside border
-    void set_outline_radius(ViewportUnits radius) { m_outline_radius = radius; }
-    ViewportUnits outline_radius() const { return m_outline_radius; }
+    void set_outline_radius(VariUnits radius) { m_outline_radius = radius; }
+    VariUnits outline_radius() const { return m_outline_radius; }
     void set_outline_color(graphics::Color color) { m_outline_color = color; }
     graphics::Color outline_color() const { return m_outline_color; }
 
@@ -76,8 +76,8 @@ public:
 
 private:
     Font* m_font = nullptr;
-    ViewportUnits m_size = 0.05_vp;  // requested font height
-    ViewportUnits m_outline_radius = 0.0_vp;  // requested outline radius
+    VariUnits m_size = 0.05_vp;  // requested font height
+    VariUnits m_outline_radius = 0.0_vp;  // requested outline radius
     graphics::Color m_color = graphics::Color::White();
     graphics::Color m_outline_color = graphics::Color::Transparent();
     FontStyle m_font_style = FontStyle::Regular;

--- a/src/xci/text/Style.h
+++ b/src/xci/text/Style.h
@@ -76,8 +76,8 @@ public:
 
 private:
     Font* m_font = nullptr;
-    VariUnits m_size = 0.05_vp;  // requested font height
-    VariUnits m_outline_radius = 0.0_vp;  // requested outline radius
+    VariUnits m_size = 2.5_vp;  // requested font height
+    VariUnits m_outline_radius = 0_fb;  // requested outline radius
     graphics::Color m_color = graphics::Color::White();
     graphics::Color m_outline_color = graphics::Color::Transparent();
     FontStyle m_font_style = FontStyle::Regular;

--- a/src/xci/text/Text.cpp
+++ b/src/xci/text/Text.cpp
@@ -1,7 +1,7 @@
 // Text.cpp created on 2018-03-02 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Text.h"
@@ -69,7 +69,7 @@ void Text::set_string(const std::string& string, Format format)
 }
 
 
-void Text::set_width(ViewportUnits width)
+void Text::set_width(VariUnits width)
 {
     m_layout.set_default_page_width(width);
     m_need_typeset = true;
@@ -83,7 +83,7 @@ void Text::set_font(Font& font)
 }
 
 
-void Text::set_font_size(ViewportUnits size, bool allow_scale)
+void Text::set_font_size(VariUnits size, bool allow_scale)
 {
     m_layout.set_default_font_size(size, allow_scale);
     m_need_typeset = true;
@@ -111,7 +111,7 @@ void Text::set_color(graphics::Color color)
 }
 
 
-void Text::set_outline_radius(ViewportUnits radius)
+void Text::set_outline_radius(VariUnits radius)
 {
     m_layout.set_default_outline_radius(radius);
     m_need_typeset = true;
@@ -125,7 +125,7 @@ void Text::set_outline_color(graphics::Color color)
 }
 
 
-void Text::set_tab_stops(std::vector<ViewportUnits> stops)
+void Text::set_tab_stops(std::vector<VariUnits> stops)
 {
     m_layout.set_default_tab_stops(std::move(stops));
     m_need_typeset = true;
@@ -159,7 +159,7 @@ void Text::update(graphics::View& view)
 }
 
 
-void Text::draw(graphics::View& view, const ViewportCoords& pos)
+void Text::draw(graphics::View& view, VariCoords pos)
 {
     m_layout.draw(view, pos);
 }

--- a/src/xci/text/Text.h
+++ b/src/xci/text/Text.h
@@ -1,7 +1,7 @@
 // Text.h created on 2018-03-02 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_TEXT_TEXT_H
@@ -18,8 +18,8 @@ namespace xci::text { class Font; }
 
 namespace xci::text {
 
-using graphics::ViewportUnits;
-using graphics::ViewportCoords;
+using graphics::VariUnits;
+using graphics::VariCoords;
 
 // Text rendering - convenient combination of Layout and Markup
 class Text {
@@ -37,22 +37,22 @@ public:
     void set_fixed_string(const std::string& string) { set_string(string, Format::None); }
     void set_markup_string(const std::string& string) { set_string(string, Format::Markup); }
 
-    void set_width(ViewportUnits width);
+    void set_width(VariUnits width);
     void set_font(Font& font);
-    void set_font_size(ViewportUnits size, bool allow_scale = true);
+    void set_font_size(VariUnits size, bool allow_scale = true);
     void set_font_style(FontStyle font_style);
     void set_font_weight(uint16_t weight);
     void set_color(graphics::Color color);
-    void set_outline_radius(ViewportUnits radius);
+    void set_outline_radius(VariUnits radius);
     void set_outline_color(graphics::Color color);
-    void set_tab_stops(std::vector<ViewportUnits> stops);
+    void set_tab_stops(std::vector<VariUnits> stops);
     void set_alignment(Alignment alignment);
 
     Layout& layout() { return m_layout; }
 
     void resize(graphics::View& view);
     void update(graphics::View& view);
-    void draw(graphics::View& view, const ViewportCoords& pos);
+    void draw(graphics::View& view, VariCoords pos);
 
 private:
     Layout m_layout;

--- a/src/xci/text/layout/Element.h
+++ b/src/xci/text/layout/Element.h
@@ -1,7 +1,7 @@
 // Element.h created on 2018-03-18 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_TEXT_LAYOUT_PAGE_ELEMENT_H
@@ -12,6 +12,9 @@
 #include <string>
 
 namespace xci::text::layout {
+
+using graphics::VariUnits;
+using graphics::VariSize;
 
 
 class Element {
@@ -27,13 +30,13 @@ public:
 
 class SetPageWidth: public Element {
 public:
-    explicit SetPageWidth(ViewportUnits width) : m_width(width) {}
+    explicit SetPageWidth(VariUnits width) : m_width(width) {}
     void apply(Page& page) override {
-        page.set_width(m_width);
+        page.set_width(page.target().to_fb(m_width));
     }
 
 private:
-    float m_width;
+    VariUnits m_width;
 };
 
 
@@ -51,13 +54,13 @@ private:
 
 class AddTabStop: public Element {
 public:
-    explicit AddTabStop(ViewportUnits tab_stop) : m_tab_stop(tab_stop) {}
+    explicit AddTabStop(VariUnits tab_stop) : m_tab_stop(tab_stop) {}
     void apply(Page& page) override {
-        page.add_tab_stop(m_tab_stop);
+        page.add_tab_stop(page.target().to_fb(m_tab_stop));
     }
 
 private:
-    float m_tab_stop;
+    VariUnits m_tab_stop;
 };
 
 
@@ -71,13 +74,13 @@ public:
 
 class SetOffset: public Element {
 public:
-    explicit SetOffset(const ViewportSize& offset) : m_offset(offset) {}
+    explicit SetOffset(VariSize offset) : m_offset(offset) {}
     void apply(Page& page) override {
-        page.set_pen_offset(m_offset);
+        page.set_pen_offset(page.target().to_fb(m_offset));
     }
 
 private:
-    const ViewportSize m_offset;
+    VariSize m_offset;
 };
 
 
@@ -95,13 +98,13 @@ private:
 
 class SetFontSize: public Element {
 public:
-    explicit SetFontSize(ViewportUnits size) : m_size(size) {}
+    explicit SetFontSize(VariUnits size) : m_size(size) {}
     void apply(Page& page) override {
         page.set_font_size(m_size);
     }
 
 private:
-    float m_size;
+    VariUnits m_size;
 };
 
 

--- a/src/xci/text/layout/Page.cpp
+++ b/src/xci/text/layout/Page.cpp
@@ -361,8 +361,9 @@ void Page::add_tab()
     // apply generic tabs
     if (x <= m_pen.x) {
         FramebufferPixels tab_size = 8 * space_width();
-        while (x <= m_pen.x)
-            x += tab_size;
+        if (tab_size > 0.f)
+            while (x <= m_pen.x)
+                x += tab_size;
     }
     // move to new position
     m_pen.x = x;

--- a/src/xci/text/layout/Page.cpp
+++ b/src/xci/text/layout/Page.cpp
@@ -150,7 +150,7 @@ void Word::update(const graphics::View& target)
         m_debug_shapes.back().update();
 
     if (target.has_debug_flag(View::Debug::WordBasePoint)) {
-        const auto sc_1px = target.size_to_viewport(1_sc);
+        const auto sc_1px = target.size_to_viewport(1_px);
         m_debug_shapes.emplace_back(renderer, Color(150, 0, 255));
         m_debug_shapes.back().add_rectangle({- sc_1px, - sc_1px, 2 * sc_1px, 2 * sc_1px});
         m_debug_shapes.back().update();

--- a/src/xci/text/layout/Page.cpp
+++ b/src/xci/text/layout/Page.cpp
@@ -11,6 +11,7 @@
 
 #include <cassert>
 #include <utility>
+#include <algorithm>
 
 namespace xci::text { class Style; }
 
@@ -261,6 +262,13 @@ void Span::adjust_style(const std::function<void(Style& word_style)>& fn_adjust)
             fn_adjust(word->style());
         }
     }
+}
+
+
+bool Span::contains(const ViewportCoords& point) const
+{
+    return std::any_of(m_parts.begin(), m_parts.end(),
+               [&point](const Line& line) { return line.bbox().contains(point); });
 }
 
 

--- a/src/xci/text/layout/Page.cpp
+++ b/src/xci/text/layout/Page.cpp
@@ -1,7 +1,7 @@
 // Page.cpp created on 2018-03-18 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include <xci/text/layout/Page.h>
@@ -35,25 +35,25 @@ Word::Word(Page& page, const std::string& utf8)
     m_style.apply_view(page.target());
     auto scale = m_style.scale();
 
-    m_baseline = page.target().size_to_viewport(FramebufferPixels{font->ascender() * scale});
-    auto descender_vp = page.target().size_to_viewport(FramebufferPixels{font->descender() * scale});
+    m_baseline = FramebufferPixels{font->ascender() * scale};
+    auto descender_vp = FramebufferPixels{font->descender() * scale};
     const auto font_height = m_baseline - descender_vp;
 
     // Measure word (metrics are affected by string, font, size)
-    ViewportCoords pen;
-    m_bbox = {0, ViewportUnits{0} - m_baseline, 0, font_height};
+    FramebufferCoords pen;
+    m_bbox = {0, 0 - m_baseline, 0, font_height};
 
     m_shaped = font->shape_text(utf8);
 
     for (const auto& shaped_glyph : m_shaped) {
         auto* glyph = font->get_glyph(shaped_glyph.glyph_index);
-        auto advance = page.target().size_to_viewport(FramebufferCoords{shaped_glyph.advance * scale});
+        auto advance = FramebufferCoords{shaped_glyph.advance * scale};
         if (glyph != nullptr) {
             // Expand text bounds by glyph bounds
-            ViewportRect rect{pen.x,
-                              pen.y - m_baseline,
-                              advance.x,
-                              font_height};
+            FramebufferRect rect{pen.x,
+                                 pen.y - m_baseline,
+                                 advance.x,
+                                 font_height};
 
             m_bbox.extend(rect);
         }
@@ -73,7 +73,7 @@ Word::Word(Page& page, const std::string& utf8)
 }
 
 
-void Word::move_x(ViewportUnits offset)
+void Word::move_x(FramebufferPixels offset)
 {
     m_pos.x += offset;
 }
@@ -92,7 +92,6 @@ void Word::update(const graphics::View& target)
 
     auto& renderer = target.window()->renderer();
 
-    const auto fb_1px = target.size_to_viewport(1_fb);
     m_debug_shapes.clear();
     m_sprites.reset();
     m_outline_sprites.reset();
@@ -101,7 +100,7 @@ void Word::update(const graphics::View& target)
         m_debug_shapes.emplace_back(renderer,
                 Color(0, 150, 0),
                 Color(50, 250, 50));
-        m_debug_shapes.back().add_rectangle(m_bbox, fb_1px);
+        m_debug_shapes.back().add_rectangle(m_bbox, 1_fb);
         m_debug_shapes.back().update();
     }
 
@@ -115,21 +114,21 @@ void Word::update(const graphics::View& target)
     auto render_sprites = [&](std::optional<graphics::Sprites>& sprites, graphics::Color color) {
         sprites.emplace(renderer, font->texture(), color);
 
-        ViewportCoords pen;
+        FramebufferCoords pen;
         for (const auto& shaped_glyph : m_shaped) {
             auto* glyph = font->get_glyph(shaped_glyph.glyph_index);
-            auto advance = target.size_to_viewport(FramebufferCoords{shaped_glyph.advance * scale});
-            auto offset = target.size_to_viewport(FramebufferSize{shaped_glyph.offset});
+            auto advance = FramebufferCoords{shaped_glyph.advance * scale};
+            auto offset = FramebufferSize{shaped_glyph.offset};
             if (glyph != nullptr) {
-                auto bearing = target.size_to_viewport(FramebufferSize{glyph->bearing()});
-                auto glyph_size = target.size_to_viewport(FramebufferSize{glyph->size()});
-                ViewportRect rect{pen.x + (offset.x + bearing.x) * scale,
-                                  pen.y + (offset.y - bearing.y) * scale,
-                                  glyph_size.x * scale,
-                                  glyph_size.y * scale};
+                auto bearing = FramebufferSize{glyph->bearing()};
+                auto glyph_size = FramebufferSize{glyph->size()};
+                FramebufferRect rect{pen.x + (offset.x + bearing.x) * scale,
+                                     pen.y + (offset.y - bearing.y) * scale,
+                                     glyph_size.x * scale,
+                                     glyph_size.y * scale};
                 sprites->add_sprite(rect, glyph->tex_coords());
                 if (show_bboxes)
-                    m_debug_shapes.back().add_rectangle(rect, fb_1px);
+                    m_debug_shapes.back().add_rectangle(rect, 1_fb);
             }
             pen += advance;
         }
@@ -150,15 +149,15 @@ void Word::update(const graphics::View& target)
         m_debug_shapes.back().update();
 
     if (target.has_debug_flag(View::Debug::WordBasePoint)) {
-        const auto sc_1px = target.size_to_viewport(1_px);
+        const auto fb_1px = target.px_to_fb(1_px);
         m_debug_shapes.emplace_back(renderer, Color(150, 0, 255));
-        m_debug_shapes.back().add_rectangle({- sc_1px, - sc_1px, 2 * sc_1px, 2 * sc_1px});
+        m_debug_shapes.back().add_rectangle({- fb_1px, - fb_1px, 2 * fb_1px, 2 * fb_1px});
         m_debug_shapes.back().update();
     }
 }
 
 
-void Word::draw(graphics::View& target, const ViewportCoords& pos) const
+void Word::draw(graphics::View& target, FramebufferCoords pos) const
 {
     for (auto& shape : m_debug_shapes) {
         shape.draw(target, m_pos + pos);
@@ -181,7 +180,7 @@ void Word::draw(graphics::View& target, const ViewportCoords& pos) const
 // -----------------------------------------------------------------------------
 
 
-const ViewportRect& Line::bbox() const
+const FramebufferRect& Line::bbox() const
 {
     if (m_bbox_valid)
         return m_bbox;
@@ -196,7 +195,7 @@ const ViewportRect& Line::bbox() const
         }
     }
     // Add padding
-    if (m_padding != 0_vp) {
+    if (m_padding != 0_fb) {
         m_bbox.x -= m_padding;
         m_bbox.y -= m_padding;
         m_bbox.w += 2 * m_padding;
@@ -207,22 +206,22 @@ const ViewportRect& Line::bbox() const
 }
 
 
-ViewportUnits Line::baseline() const
+FramebufferPixels Line::baseline() const
 {
     if (m_words.empty())
-        return 0_vp;
+        return 0_fb;
     return m_words[0]->baseline();
 }
 
 
-void Line::align(Alignment alignment, ViewportUnits width)
+void Line::align(Alignment alignment, FramebufferPixels width)
 {
     // This also computes bbox if not valid
     auto line_width = bbox().w - 2 * m_padding;
     if (line_width >= width)
         return;  // Not enough space for aligning
     auto current_x = m_bbox.x + m_padding;
-    ViewportUnits target_x;
+    FramebufferPixels target_x;
     switch (alignment) {
         case Alignment::Justify:  // not implemented, fallback to Left
         case Alignment::Left:
@@ -265,7 +264,7 @@ void Span::adjust_style(const std::function<void(Style& word_style)>& fn_adjust)
 }
 
 
-bool Span::contains(const ViewportCoords& point) const
+bool Span::contains(FramebufferCoords point) const
 {
     return std::any_of(m_parts.begin(), m_parts.end(),
                [&point](const Line& line) { return line.bbox().contains(point); });
@@ -308,7 +307,7 @@ void Page::clear()
 }
 
 
-void Page::add_tab_stop(ViewportUnits x)
+void Page::add_tab_stop(FramebufferPixels x)
 {
     m_tab_stops.push_back(x);
     std::sort(m_tab_stops.begin(), m_tab_stops.end());
@@ -340,7 +339,7 @@ void Page::finish_line()
 void Page::advance_line(float lines)
 {
     m_style.apply_view(target());
-    auto height = target().size_to_viewport(FramebufferPixels{m_style.font()->height() * m_style.scale()});
+    auto height = FramebufferPixels{m_style.font()->height() * m_style.scale()};
     m_pen.y += lines * height;
 }
 
@@ -355,13 +354,13 @@ void Page::add_tab()
 {
     // apply tab stops
     auto tab_stop = m_tab_stops.begin();
-    ViewportUnits x = 0_vp;
+    FramebufferPixels x = 0;
     while (x <= m_pen.x && tab_stop != m_tab_stops.end()) {
         x = *tab_stop++;
     }
     // apply generic tabs
     if (x <= m_pen.x) {
-        ViewportUnits tab_size = 8 * space_width();
+        FramebufferPixels tab_size = 8 * space_width();
         while (x <= m_pen.x)
             x += tab_size;
     }
@@ -388,11 +387,11 @@ void Page::add_word(const std::string& string)
 }
 
 
-ViewportUnits Page::space_width()
+FramebufferPixels Page::space_width()
 {
     m_style.apply_view(target());
     auto* glyph = m_style.font()->get_glyph_for_char(' ');
-    return target().size_to_viewport(FramebufferPixels{glyph->advance() * m_style.scale()});
+    return FramebufferPixels{glyph->advance() * m_style.scale()};
 }
 
 

--- a/src/xci/text/layout/Page.h
+++ b/src/xci/text/layout/Page.h
@@ -1,7 +1,7 @@
 // Page.h created on 2018-03-18 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_TEXT_LAYOUT_PAGE_H
@@ -22,13 +22,10 @@ namespace xci::text { class Font; }
 
 namespace xci::text::layout {
 
-using graphics::ScreenPixels;
 using graphics::FramebufferPixels;
 using graphics::FramebufferCoords;
 using graphics::FramebufferSize;
-using graphics::ViewportCoords;
-using graphics::ViewportSize;
-using graphics::ViewportRect;
+using graphics::FramebufferRect;
 
 class Layout;
 class Page;
@@ -38,22 +35,22 @@ class Word {
 public:
     Word(Page& page, const std::string& utf8);
 
-    ViewportRect bbox() const { return m_bbox.moved(m_pos); }
-    ViewportUnits baseline() const { return m_baseline; }
+    FramebufferRect bbox() const { return m_bbox.moved(m_pos); }
+    FramebufferPixels baseline() const { return m_baseline; }
     Style& style() { return m_style; }
 
     // Reposition the word on x-axis
-    void move_x(ViewportUnits offset);
+    void move_x(FramebufferPixels offset);
 
     void update(const graphics::View& target);
-    void draw(graphics::View& target, const ViewportCoords& pos) const;
+    void draw(graphics::View& target, FramebufferCoords pos) const;
 
 private:
     std::vector<FontFace::GlyphPlacement> m_shaped;
     Style m_style;
-    ViewportCoords m_pos;  // relative to page origin (top-left corner)
-    ViewportRect m_bbox;
-    ViewportUnits m_baseline = 0;  // relative to bbox top
+    FramebufferCoords m_pos;  // relative to page origin (top-left corner)
+    FramebufferRect m_bbox;
+    FramebufferPixels m_baseline = 0;  // relative to bbox top
 
     mutable std::optional<graphics::Sprites> m_sprites;
     mutable std::optional<graphics::Sprites> m_outline_sprites;
@@ -69,19 +66,19 @@ public:
     bool is_empty() const { return m_words.empty(); }
 
     // Retrieve bounding box of the whole line, relative to page
-    const ViewportRect& bbox() const;
-    ViewportUnits baseline() const;
+    const FramebufferRect& bbox() const;
+    FramebufferPixels baseline() const;
 
     // Align content of the line
-    void align(Alignment alignment, ViewportUnits width);
+    void align(Alignment alignment, FramebufferPixels width);
 
     // Padding to be added to each side of the bounding box
-    void set_padding(ViewportUnits padding) { m_padding = padding; m_bbox_valid = false; }
+    void set_padding(FramebufferPixels padding) { m_padding = padding; m_bbox_valid = false; }
 
 private:
     std::vector<Word*> m_words;
-    ViewportUnits m_padding = 0;
-    mutable ViewportRect m_bbox;
+    FramebufferPixels m_padding = 0;
+    mutable FramebufferRect m_bbox;
     mutable bool m_bbox_valid = false;
 };
 
@@ -109,7 +106,7 @@ public:
     // Convenience shortcuts for `adjust_style`:
     void adjust_color(graphics::Color c) { adjust_style([c](Style& w){ w.set_color(c); }); }
 
-    bool contains(const ViewportCoords& point) const;
+    bool contains(FramebufferCoords point) const;
 
 private:
     std::vector<Line> m_parts;
@@ -133,7 +130,7 @@ public:
 
     // Text style
     void set_font(Font* font) { m_style.set_font(font); }
-    void set_font_size(ViewportUnits size) { m_style.set_size(size); }
+    void set_font_size(VariUnits size) { m_style.set_size(size); }
     void set_font_style(FontStyle font_style) { m_style.set_font_style(font_style); }
     void set_color(graphics::Color color) { m_style.set_color(color); }
     void set_style(const Style& style) { m_style = style; }
@@ -141,27 +138,27 @@ public:
 
     // Set page width. This drives the line breaking.
     // Default: 0 (same as INF - no line breaking)
-    void set_width(ViewportUnits width) { m_width = width; }
-    ViewportUnits width() const { return m_width; }
+    void set_width(FramebufferPixels width) { m_width = width; }
+    FramebufferPixels width() const { return m_width; }
 
     void set_alignment(Alignment alignment) { m_alignment = alignment; }
     Alignment get_alignment() const { return m_alignment; }
 
-    void add_tab_stop(ViewportUnits x);
+    void add_tab_stop(FramebufferPixels x);
     void reset_tab_stops() { m_tab_stops.clear(); }
 
     // ------------------------------------------------------------------------
 
     // Pen is a position in page where elements are printed
-    void set_pen(ViewportCoords pen) { m_pen = pen; m_pen_offset = {}; }
-    ViewportCoords pen() const { return m_pen + m_pen_offset; }
+    void set_pen(FramebufferCoords pen) { m_pen = pen; m_pen_offset = {}; }
+    FramebufferCoords pen() const { return m_pen + m_pen_offset; }
 
     // Advance pen. The relative coords should be positive, don't move back.
-    void advance_pen(ViewportSize advance) { m_pen += advance; }
+    void advance_pen(FramebufferSize advance) { m_pen += advance; }
 
     // Offset pen position. Can be used for subscript/superscript etc.
-    void set_pen_offset(ViewportSize pen_offset) { m_pen_offset = pen_offset; }
-    ViewportSize pen_offset() const { return m_pen_offset; }
+    void set_pen_offset(FramebufferSize pen_offset) { m_pen_offset = pen_offset; }
+    FramebufferSize pen_offset() const { return m_pen_offset; }
 
     // Finish current line, apply alignment and move to next one.
     // Does nothing if current line is empty.
@@ -200,20 +197,20 @@ public:
     void foreach_span(const std::function<void(const Span& span)>& cb) const;
 
 private:
-    ViewportUnits space_width();
+    FramebufferPixels space_width();
 
 private:
     const graphics::View* m_target = nullptr;
 
     // running state
-    ViewportCoords m_pen;  // pen position
-    ViewportSize m_pen_offset;
+    FramebufferCoords m_pen;  // pen position
+    FramebufferSize m_pen_offset;
     Style m_style;  // text style
 
     // page attributes
-    ViewportUnits m_width = ViewportUnits{0};  // page width
+    FramebufferPixels m_width = 0;  // page width
     Alignment m_alignment = Alignment::Left;  // horizontal alignment
-    std::vector<ViewportUnits> m_tab_stops;
+    std::vector<FramebufferPixels> m_tab_stops;
 
     // page content
     core::ChunkedStack<Word> m_words;

--- a/src/xci/text/layout/Page.h
+++ b/src/xci/text/layout/Page.h
@@ -106,6 +106,11 @@ public:
     // with reference to the word's current style to be adjusted.
     void adjust_style(const std::function<void(Style& word_style)>& fn_adjust);
 
+    // Convenience shortcuts for `adjust_style`:
+    void adjust_color(graphics::Color c) { adjust_style([c](Style& w){ w.set_color(c); }); }
+
+    bool contains(const ViewportCoords& point) const;
+
 private:
     std::vector<Line> m_parts;
     bool m_open = true;

--- a/src/xci/widgets/Button.cpp
+++ b/src/xci/widgets/Button.cpp
@@ -1,7 +1,7 @@
 // Button.cpp created on 2018-03-21 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Button.h"
@@ -42,17 +42,19 @@ void Button::set_text_color(graphics::Color color)
 
 void Button::resize(View& view)
 {
+    view.finish_draw();
     m_layout.typeset(view);
     m_layout.update(view);
     auto rect = m_layout.bbox();
-    rect.enlarge(m_padding);
+    rect.enlarge(view.to_fb(m_padding));
     set_size(rect.size());
     set_baseline(-rect.y);
+    Widget::resize(view);
 
     rect.x = 0;
     rect.y = 0;
     m_bg_rect.clear();
-    m_bg_rect.add_rectangle(rect, m_outline_thickness);
+    m_bg_rect.add_rectangle(rect, view.to_fb(m_outline_thickness));
     m_bg_rect.update();
 }
 
@@ -72,9 +74,10 @@ void Button::update(View& view, State state)
 
 void Button::draw(View& view)
 {
-    auto rect = m_layout.bbox();
+    const auto layout_pos = m_layout.bbox().top_left();
+    const auto padding = view.to_fb(m_padding);
     m_bg_rect.draw(view, position());
-    m_layout.draw(view, position() + ViewportCoords{m_padding - rect.x, m_padding - rect.y});
+    m_layout.draw(view, position() + FramebufferCoords{padding - layout_pos.x, padding - layout_pos.y});
 }
 
 

--- a/src/xci/widgets/Button.h
+++ b/src/xci/widgets/Button.h
@@ -1,7 +1,7 @@
 // Button.h created on 2018-03-21 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_WIDGETS_BUTTON_H
@@ -15,14 +15,16 @@
 
 namespace xci::widgets {
 
+using namespace xci::graphics::unit_literals;
+
 
 class Button: public Widget, public Clickable {
 public:
     explicit Button(Theme& theme, const std::string &string);
 
-    void set_font_size(ViewportUnits size) { m_layout.set_default_font_size(size); }
-    void set_padding(ViewportUnits padding) { m_padding = padding; }
-    void set_outline_thickness(ViewportUnits thickness) { m_outline_thickness = thickness; }
+    void set_font_size(VariUnits size) { m_layout.set_default_font_size(size); }
+    void set_padding(VariUnits padding) { m_padding = padding; }
+    void set_outline_thickness(VariUnits thickness) { m_outline_thickness = thickness; }
 
     void set_decoration_color(graphics::Color fill, graphics::Color outline);
     void set_text_color(graphics::Color color);
@@ -37,8 +39,8 @@ public:
 private:
     graphics::Shape m_bg_rect;
     text::Layout m_layout;
-    ViewportUnits m_padding = 0.02f;
-    ViewportUnits m_outline_thickness = 0.005f;
+    VariUnits m_padding = 0.02_vp;
+    VariUnits m_outline_thickness = 0.005_vp;
 };
 
 

--- a/src/xci/widgets/Button.h
+++ b/src/xci/widgets/Button.h
@@ -39,8 +39,8 @@ public:
 private:
     graphics::Shape m_bg_rect;
     text::Layout m_layout;
-    VariUnits m_padding = 0.02_vp;
-    VariUnits m_outline_thickness = 0.005_vp;
+    VariUnits m_padding = 1_vp;
+    VariUnits m_outline_thickness = 0.25_vp;
 };
 
 

--- a/src/xci/widgets/Form.cpp
+++ b/src/xci/widgets/Form.cpp
@@ -78,7 +78,7 @@ void Form::resize(View& view)
                 case Hint::None:
                     break;
                 case Hint::NextColumn:
-                    pos.x = view.vp_to_fb(0.5f);
+                    pos.x = view.vp_to_fb(25_vp);
                     break;
                 case Hint::NextRow:
                     pos.x = 0;

--- a/src/xci/widgets/Form.cpp
+++ b/src/xci/widgets/Form.cpp
@@ -1,7 +1,7 @@
 // Form.cpp created on 2018-06-22 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Form.h"
@@ -47,20 +47,23 @@ void Form::add_input(const std::string& label, bool& checkbox)
 
 void Form::resize(View& view)
 {
+    Composite::resize(view);
+    view.finish_draw();
+
     // Resize children, compute max_height (vertical space reserved for each line)
-    ViewportUnits max_ascent = 0;
-    ViewportUnits max_descent = 0;
+    FramebufferPixels max_ascent = 0;
+    FramebufferPixels max_descent = 0;
     for (auto& child : m_child) {
-        child->resize(view);
         auto h = child->size().y;
         auto b = child->baseline();
         max_ascent = std::max(b, max_ascent);
         max_descent = std::max(h - b, max_descent);
     }
-    const ViewportUnits max_height = max_ascent + max_descent;
+    const auto max_height = max_ascent + max_descent;
 
     // Position children
-    ViewportCoords pos = {0, max_ascent};
+    FramebufferCoords pos = {0, max_ascent};
+    const auto margin = view.to_fb(m_margin);
     std::sort(m_hint.begin(), m_hint.end());
     size_t index = 0;
     auto hint_it = m_hint.cbegin();
@@ -75,11 +78,11 @@ void Form::resize(View& view)
                 case Hint::None:
                     break;
                 case Hint::NextColumn:
-                    pos.x = 0.5f;
+                    pos.x = view.vp_to_fb(0.5f);
                     break;
                 case Hint::NextRow:
                     pos.x = 0;
-                    pos.y += max_height + m_margin.y;
+                    pos.y += max_height + margin.y;
                     break;
             }
             hint_it++;
@@ -87,7 +90,7 @@ void Form::resize(View& view)
 
         // Position child
         child->set_position({pos.x, pos.y - child->baseline()});
-        pos.x += child->size().x + m_margin.x;
+        pos.x += child->size().x + margin.x;
         ++index;
     }
 }

--- a/src/xci/widgets/Form.h
+++ b/src/xci/widgets/Form.h
@@ -1,7 +1,7 @@
 // Form.h created on 2018-06-22 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_WIDGETS_FORM_H
@@ -14,6 +14,8 @@
 #include <xci/core/container/ChunkedStack.h>
 
 namespace xci::widgets {
+
+using namespace graphics::unit_literals;
 
 
 class Form: public Composite {
@@ -37,7 +39,7 @@ public:
     void resize(View& view) override;
 
 private:
-    ViewportCoords m_margin = {0.02f, 0.02f};
+    VariCoords m_margin = {0.02_vp, 0.02_vp};
 
     struct ChildHint {
         size_t child_index;

--- a/src/xci/widgets/Form.h
+++ b/src/xci/widgets/Form.h
@@ -39,7 +39,7 @@ public:
     void resize(View& view) override;
 
 private:
-    VariCoords m_margin = {0.02_vp, 0.02_vp};
+    VariCoords m_margin = {1_vp, 1_vp};
 
     struct ChildHint {
         size_t child_index;

--- a/src/xci/widgets/FpsDisplay.cpp
+++ b/src/xci/widgets/FpsDisplay.cpp
@@ -1,7 +1,7 @@
 // FpsDisplay.cpp created on 2018-04-14 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "FpsDisplay.h"
@@ -27,15 +27,17 @@ FpsDisplay::FpsDisplay(Theme& theme)
     m_texture.create({(unsigned)m_fps.resolution(), 1});
 
     // default size in "scalable" units
-    set_size({0.50f, 0.10f});
-    create_sprite();
+    set_size({0.50_vp, 0.10_vp});
 }
 
 
 void FpsDisplay::resize(View& view)
 {
+    Widget::resize(view);
+    view.finish_draw();
+
     m_quad.clear();
-    create_sprite();
+    create_sprite(view);
 
     m_text.set_font(theme().font());
     m_text.set_font_size(size().y / 2);
@@ -82,14 +84,14 @@ void FpsDisplay::draw(View& view)
 
     auto font_size = size().y / 2;
     auto offset = size().y / 5;
-    m_text.draw(view, position() + ViewportCoords{offset, offset + font_size});
+    m_text.draw(view, position() + FramebufferCoords{offset, offset + font_size});
 }
 
 
-void FpsDisplay::create_sprite()
+void FpsDisplay::create_sprite(View& view)
 {
-    auto x1 = 0_vp;
-    auto y1 = 0_vp;
+    auto x1 = 0_fb;
+    auto y1 = 0_fb;
     auto x2 = size().x;
     auto y2 = size().y;
     m_quad.reserve(4);

--- a/src/xci/widgets/FpsDisplay.cpp
+++ b/src/xci/widgets/FpsDisplay.cpp
@@ -27,7 +27,7 @@ FpsDisplay::FpsDisplay(Theme& theme)
     m_texture.create({(unsigned)m_fps.resolution(), 1});
 
     // default size in "scalable" units
-    set_size({0.50_vp, 0.10_vp});
+    set_size({25_vp, 5_vp});
 }
 
 

--- a/src/xci/widgets/FpsDisplay.h
+++ b/src/xci/widgets/FpsDisplay.h
@@ -1,7 +1,7 @@
 // FpsDisplay.h created on 2018-04-14 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCIKIT_FPSDISPLAY_H
@@ -25,7 +25,7 @@ public:
     void draw(View& view) override;
 
 private:
-    void create_sprite();
+    void create_sprite(View& view);
     void update_texture();
 
 private:

--- a/src/xci/widgets/Icon.cpp
+++ b/src/xci/widgets/Icon.cpp
@@ -1,7 +1,7 @@
 // Icon.cpp created on 2018-04-10 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Icon.h"
@@ -28,7 +28,7 @@ void Icon::set_text(const std::string& text)
 }
 
 
-void Icon::set_font_size(float size)
+void Icon::set_font_size(graphics::VariUnits size)
 {
     m_layout.set_default_font_size(size);
     m_needs_refresh = true;
@@ -56,7 +56,7 @@ void Icon::resize(View& view)
         m_layout.clear();
         m_layout.set_font(&theme().icon_font());
         m_layout.begin_span("icon");
-        m_layout.set_offset({0_vp, 0.125f * m_layout.default_style().size()});
+        m_layout.set_offset({0_fb, 0.125f * view.to_fb(m_layout.default_style().size())});
         m_layout.add_word(to_utf8(theme().icon_codepoint(m_icon_id)));
         m_layout.end_span("icon");
         m_layout.reset_offset();
@@ -70,6 +70,7 @@ void Icon::resize(View& view)
     auto rect = m_layout.bbox();
     set_size(rect.size());
     set_baseline(-rect.y);
+    Widget::resize(view);
 }
 
 

--- a/src/xci/widgets/Icon.h
+++ b/src/xci/widgets/Icon.h
@@ -1,7 +1,7 @@
 // Icon.h created on 2018-04-10 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_WIDGETS_ICON_H
@@ -19,7 +19,7 @@ public:
 
     void set_icon(IconId icon_id);
     void set_text(const std::string& text);
-    void set_font_size(float size);
+    void set_font_size(graphics::VariUnits size);
     void set_icon_color(graphics::Color color);
     void set_color(graphics::Color color);
 

--- a/src/xci/widgets/Label.cpp
+++ b/src/xci/widgets/Label.cpp
@@ -39,11 +39,10 @@ void Label::resize(View& view)
 
 void Label::draw(View& view)
 {
-    view.push_offset(position());
+    auto pop_offset = view.push_offset(position());
     auto rect = m_text.layout().bbox();
     FramebufferCoords pos = {m_padding - rect.x, m_padding - rect.y};
     m_text.draw(view, pos);
-    view.pop_offset();
 }
 
 

--- a/src/xci/widgets/Label.cpp
+++ b/src/xci/widgets/Label.cpp
@@ -30,7 +30,7 @@ void Label::resize(View& view)
     view.finish_draw();
     m_text.resize(view);
     auto rect = m_text.layout().bbox();
-    rect.enlarge(m_padding);
+    rect.enlarge(view.to_fb(m_padding));
     set_size(rect.size());
     set_baseline(-rect.y);
     Widget::resize(view);
@@ -41,7 +41,8 @@ void Label::draw(View& view)
 {
     auto pop_offset = view.push_offset(position());
     auto rect = m_text.layout().bbox();
-    FramebufferCoords pos = {m_padding - rect.x, m_padding - rect.y};
+    const auto padding = view.to_fb(m_padding);
+    FramebufferCoords pos = {padding - rect.x, padding - rect.y};
     m_text.draw(view, pos);
 }
 

--- a/src/xci/widgets/Label.cpp
+++ b/src/xci/widgets/Label.cpp
@@ -1,12 +1,14 @@
 // Label.cpp created on 2018-06-23 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Label.h"
 
 namespace xci::widgets {
+
+using graphics::FramebufferCoords;
 
 
 Label::Label(Theme& theme)
@@ -31,6 +33,7 @@ void Label::resize(View& view)
     rect.enlarge(m_padding);
     set_size(rect.size());
     set_baseline(-rect.y);
+    Widget::resize(view);
 }
 
 
@@ -38,8 +41,7 @@ void Label::draw(View& view)
 {
     view.push_offset(position());
     auto rect = m_text.layout().bbox();
-    auto pos = ViewportCoords{m_padding - rect.x,
-                              m_padding - rect.y};
+    FramebufferCoords pos = {m_padding - rect.x, m_padding - rect.y};
     m_text.draw(view, pos);
     view.pop_offset();
 }

--- a/src/xci/widgets/Label.h
+++ b/src/xci/widgets/Label.h
@@ -1,7 +1,7 @@
 // Label.h created on 2018-06-23 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCIKIT_LABEL_H
@@ -11,6 +11,8 @@
 #include <xci/text/Text.h>
 
 namespace xci::widgets {
+
+using namespace xci::graphics::unit_literals;
 
 
 class Label: public Widget {
@@ -25,7 +27,7 @@ public:
 
 private:
     text::Text m_text;
-    float m_padding = 0.02f;
+    VariUnits m_padding = 1_vp;
 };
 
 

--- a/src/xci/widgets/TextInput.cpp
+++ b/src/xci/widgets/TextInput.cpp
@@ -1,7 +1,7 @@
 // TextInput.cpp created on 2018-06-02 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "TextInput.h"
@@ -59,25 +59,27 @@ void TextInput::resize(View& view)
     layout::Span* cursor_span = m_layout.get_span("cursor");
     m_cursor_shape.clear();
     auto cursor_box = cursor_span->part(0).bbox();
-    cursor_box.w = view.size_to_viewport(1_px);
+    cursor_box.w = view.px_to_fb(1_px);
     if (cursor_box.x < m_content_pos)
         m_content_pos = cursor_box.x;
-    if (cursor_box.x > m_content_pos + m_width)
-        m_content_pos = cursor_box.x - m_width;
+    const auto width = view.to_fb(m_width);
+    if (cursor_box.x > m_content_pos + width)
+        m_content_pos = cursor_box.x - width;
     m_cursor_shape.add_rectangle(cursor_box);
     m_cursor_shape.update();
 
     auto rect = m_layout.bbox();
-    rect.w = m_width;
-    rect.enlarge(m_padding);
+    rect.w = width;
+    rect.enlarge(view.to_fb(m_padding));
     set_size(rect.size());
     set_baseline(-rect.y);
+    Widget::resize(view);
 
     // Background rect
     rect.x = 0;
     rect.y = 0;
     m_bg_rect.clear();
-    m_bg_rect.add_rectangle(rect, m_outline_thickness);
+    m_bg_rect.add_rectangle(rect, view.to_fb(m_outline_thickness));
     m_bg_rect.update();
 }
 
@@ -101,10 +103,11 @@ void TextInput::update(View& view, State state)
 void TextInput::draw(View& view)
 {
     auto rect = m_layout.bbox();
-    auto pos = position() + ViewportCoords{m_padding - rect.x - m_content_pos,
-                                           m_padding - rect.y};
+    const auto padding = view.to_fb(m_padding);
+    auto pos = position() + FramebufferCoords{padding - rect.x - m_content_pos,
+                                              padding - rect.y};
     m_bg_rect.draw(view, position());
-    view.push_crop(aabb().enlarged(-m_outline_thickness));
+    view.push_crop(aabb().enlarged(-view.to_fb(m_outline_thickness)));
     m_layout.draw(view, pos);
     if (m_draw_cursor)
         m_cursor_shape.draw(view, pos);

--- a/src/xci/widgets/TextInput.cpp
+++ b/src/xci/widgets/TextInput.cpp
@@ -107,11 +107,10 @@ void TextInput::draw(View& view)
     auto pos = position() + FramebufferCoords{padding - rect.x - m_content_pos,
                                               padding - rect.y};
     m_bg_rect.draw(view, position());
-    view.push_crop(aabb().enlarged(-view.to_fb(m_outline_thickness)));
+    auto pop_crop = view.push_crop(aabb().enlarged(-view.to_fb(m_outline_thickness)));
     m_layout.draw(view, pos);
     if (m_draw_cursor)
         m_cursor_shape.draw(view, pos);
-    view.pop_crop();
 }
 
 

--- a/src/xci/widgets/TextInput.cpp
+++ b/src/xci/widgets/TextInput.cpp
@@ -59,7 +59,7 @@ void TextInput::resize(View& view)
     layout::Span* cursor_span = m_layout.get_span("cursor");
     m_cursor_shape.clear();
     auto cursor_box = cursor_span->part(0).bbox();
-    cursor_box.w = view.size_to_viewport(1_sc);
+    cursor_box.w = view.size_to_viewport(1_px);
     if (cursor_box.x < m_content_pos)
         m_content_pos = cursor_box.x;
     if (cursor_box.x > m_content_pos + m_width)

--- a/src/xci/widgets/TextInput.h
+++ b/src/xci/widgets/TextInput.h
@@ -15,6 +15,7 @@
 namespace xci::widgets {
 
 using xci::graphics::VariUnits;
+using xci::graphics::FramebufferPixels;
 using namespace xci::graphics::unit_literals;
 
 
@@ -49,10 +50,10 @@ private:
     text::Layout m_layout;
     graphics::Shape m_bg_rect;
     graphics::Shape m_cursor_shape;
-    VariUnits m_width = 0.4_vp;
-    VariUnits m_padding = 0.02_vp;
-    VariUnits m_outline_thickness = 0.005_vp;
-    graphics::FramebufferPixels m_content_pos = 0;
+    VariUnits m_width = 20_vp;
+    VariUnits m_padding = 1_vp;
+    VariUnits m_outline_thickness = 0.25_vp;
+    FramebufferPixels m_content_pos = 0;
     ChangeCallback m_change_cb;
     bool m_draw_cursor = false;
 };

--- a/src/xci/widgets/TextInput.h
+++ b/src/xci/widgets/TextInput.h
@@ -1,7 +1,7 @@
 // TextInput.h created on 2018-06-02 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_WIDGETS_TEXTINPUT_H
@@ -14,6 +14,9 @@
 
 namespace xci::widgets {
 
+using xci::graphics::VariUnits;
+using namespace xci::graphics::unit_literals;
+
 
 class TextInput: public Widget, public Clickable {
 public:
@@ -22,10 +25,10 @@ public:
     void set_string(const std::string& string);
     const std::string& string() const { return m_buffer.content(); }
 
-    void set_font_size(ViewportUnits size) { m_layout.set_default_font_size(size); }
-    void set_width(ViewportUnits width) { m_width = width; }
-    void set_padding(ViewportUnits padding) { m_padding = padding; }
-    void set_outline_thickness(ViewportUnits thickness) { m_outline_thickness = thickness; }
+    void set_font_size(VariUnits size) { m_layout.set_default_font_size(size); }
+    void set_width(VariUnits width) { m_width = width; }
+    void set_padding(VariUnits padding) { m_padding = padding; }
+    void set_outline_thickness(VariUnits thickness) { m_outline_thickness = thickness; }
 
     void set_decoration_color(graphics::Color fill, graphics::Color outline);
     void set_text_color(graphics::Color color) { m_layout.set_default_color(color); }
@@ -46,10 +49,10 @@ private:
     text::Layout m_layout;
     graphics::Shape m_bg_rect;
     graphics::Shape m_cursor_shape;
-    ViewportUnits m_width = 0.4f;
-    ViewportUnits m_padding = 0.02f;
-    ViewportUnits m_content_pos = 0;
-    ViewportUnits m_outline_thickness = 0.005f;
+    VariUnits m_width = 0.4_vp;
+    VariUnits m_padding = 0.02_vp;
+    VariUnits m_outline_thickness = 0.005_vp;
+    graphics::FramebufferPixels m_content_pos = 0;
     ChangeCallback m_change_cb;
     bool m_draw_cursor = false;
 };

--- a/src/xci/widgets/TextTerminal.cpp
+++ b/src/xci/widgets/TextTerminal.cpp
@@ -827,7 +827,7 @@ void TextTerminal::resize(View& view)
 
     m_frame.clear();
     m_frame.add_rectangle(FramebufferRect{{0, 0}, size()},
-                          view.vp_to_fb(0.01_vp));
+                          view.vp_to_fb(0.5_vp));
     m_frame.update();
 }
 
@@ -970,11 +970,10 @@ void TextTerminal::update(View& view, State state)
                         glyph = font.get_glyph_for_char(' ');
 
                     auto bearing = FramebufferSize{glyph->bearing()};
-                    auto ascender_vp = FramebufferPixels{ascender};
                     auto glyph_size = FramebufferSize{glyph->size()};
                     term.m_sprites.add_sprite({
                             pen.x + bearing.x,
-                            pen.y + (ascender_vp - bearing.y),
+                            pen.y + (ascender - bearing.y),
                             glyph_size.x,
                             glyph_size.y
                     }, glyph->tex_coords());
@@ -1000,12 +999,11 @@ void TextTerminal::update(View& view, State state)
 
                     const auto& cell_size = term.m_cell_size;
                     auto bearing = FramebufferSize{glyph->bearing()};
-                    auto ascender_vp = FramebufferPixels{ascender};
                     auto glyph_size = FramebufferSize{glyph->size()};
                     const auto scale = cell_size.y / glyph_size.y;
                     term.m_emoji_sprites.add_sprite({
                             pen.x + bearing.x * scale,
-                            pen.y + (ascender_vp - bearing.y * scale),
+                            pen.y + (ascender - bearing.y * scale),
                             glyph_size.x * scale,
                             glyph_size.y * scale
                     }, glyph->tex_coords());
@@ -1022,7 +1020,7 @@ void TextTerminal::update(View& view, State state)
             size_t& column;
             text::Font& font;
             text::Font& emoji_font;
-            float ascender;
+            FramebufferPixels ascender;
             Color8bit m_fg = 7;
             Color8bit m_bg = 0;
             Mode m_mode = Mode::Normal;

--- a/src/xci/widgets/TextTerminal.cpp
+++ b/src/xci/widgets/TextTerminal.cpp
@@ -568,7 +568,7 @@ void terminal::Caret::update(View& view, const ViewportRect& rect)
     auto y1 = rect.y;
     auto x2 = rect.x + rect.w;
     auto y2 = rect.y + rect.h;
-    auto outline_thickness = view.size_to_viewport(1.0_sc);
+    auto outline_thickness = view.size_to_viewport(1_px);
     float tx = 2.0f * outline_thickness.value / rect.w.value;
     float ty = 2.0f * outline_thickness.value / rect.h.value;
     float ix = 1.0f + tx / (1.0f - tx);

--- a/src/xci/widgets/TextTerminal.cpp
+++ b/src/xci/widgets/TextTerminal.cpp
@@ -1,7 +1,7 @@
 // TextTerminal.cpp created on 2018-07-19 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "TextTerminal.h"
@@ -560,7 +560,7 @@ void terminal::Buffer::remove_lines(size_t start, size_t count)
 // ------------------------------------------------------------------------
 
 
-void terminal::Caret::update(View& view, const ViewportRect& rect)
+void terminal::Caret::update(View& view, const FramebufferRect& rect)
 {
     view.finish_draw();
 
@@ -568,7 +568,7 @@ void terminal::Caret::update(View& view, const ViewportRect& rect)
     auto y1 = rect.y;
     auto x2 = rect.x + rect.w;
     auto y2 = rect.y + rect.h;
-    auto outline_thickness = view.size_to_viewport(1_px);
+    auto outline_thickness = view.px_to_vp(1_px);
     float tx = 2.0f * outline_thickness.value / rect.w.value;
     float ty = 2.0f * outline_thickness.value / rect.h.value;
     float ix = 1.0f + tx / (1.0f - tx);
@@ -595,7 +595,7 @@ void terminal::Caret::update(View& view, const ViewportRect& rect)
 }
 
 
-void terminal::Caret::draw(View& view, const ViewportCoords& pos)
+void terminal::Caret::draw(View& view, VariCoords pos)
 {
     m_quad.draw(view, pos);
 }
@@ -616,7 +616,7 @@ TextTerminal::TextTerminal(Theme& theme)
 }
 
 
-void TextTerminal::set_font_size(ViewportUnits size)
+void TextTerminal::set_font_size(VariUnits size)
 {
     m_font_size_requested = size;
     m_font_size = 0;
@@ -815,18 +815,19 @@ void TextTerminal::cancel_scrollback()
 
 void TextTerminal::resize(View& view)
 {
+    Widget::resize(view);
     auto& font = theme().font();
-    m_font_size = view.size_to_framebuffer(m_font_size_requested);
+    m_font_size = view.to_fb(m_font_size_requested);
     font.set_size(m_font_size.as<unsigned>());
-    m_cell_size = view.size_to_viewport(FramebufferSize{
-            font.max_advance(), font.height()});
+    m_cell_size = {font.max_advance(), font.height()};
     if (m_resize_cells) {
         m_cells = {(size().x / m_cell_size.x).as<unsigned>(),
                    (size().y / m_cell_size.y).as<unsigned>()};
     }
 
     m_frame.clear();
-    m_frame.add_rectangle({{0, 0}, size()}, 0.01f);
+    m_frame.add_rectangle(FramebufferRect{{0, 0}, size()},
+                          view.vp_to_fb(0.01_vp));
     m_frame.update();
 }
 
@@ -848,7 +849,7 @@ void TextTerminal::update(View& view, State state)
     m_boxes.clear();
     m_boxes.reserve(0, expected_num_cells, 0);
 
-    ViewportCoords pen;
+    FramebufferCoords pen;
     size_t buffer_first, buffer_last;
     if (m_scroll_offset == c_scroll_end) {
         buffer_first = m_buffer_offset;
@@ -872,11 +873,10 @@ void TextTerminal::update(View& view, State state)
         class LineRenderer: public terminal::Renderer {
         public:
             // capture by ref
-            LineRenderer(TextTerminal& term, ViewportCoords& pen, size_t& column,
-                    text::Font& font, text::Font& emoji_font, View& view)
+            LineRenderer(TextTerminal& term, FramebufferCoords& pen, size_t& column,
+                    text::Font& font, text::Font& emoji_font)
                     : term(term), pen(pen), column(column),
-                      font(font), emoji_font(emoji_font), ascender(font.ascender()),
-                      view(view)
+                      font(font), emoji_font(emoji_font), ascender(font.ascender())
             {}
 
             void set_font_style(FontStyle font_style) override {
@@ -969,9 +969,9 @@ void TextTerminal::update(View& view, State state)
                     if (glyph == nullptr)
                         glyph = font.get_glyph_for_char(' ');
 
-                    auto bearing = view.size_to_viewport(FramebufferSize{glyph->bearing()});
-                    auto ascender_vp = view.size_to_viewport(FramebufferPixels{ascender});
-                    auto glyph_size = view.size_to_viewport(FramebufferSize{glyph->size()});
+                    auto bearing = FramebufferSize{glyph->bearing()};
+                    auto ascender_vp = FramebufferPixels{ascender};
+                    auto glyph_size = FramebufferSize{glyph->size()};
                     term.m_sprites.add_sprite({
                             pen.x + bearing.x,
                             pen.y + (ascender_vp - bearing.y),
@@ -999,9 +999,9 @@ void TextTerminal::update(View& view, State state)
                         return shaped_glyph.char_index;
 
                     const auto& cell_size = term.m_cell_size;
-                    auto bearing = view.size_to_viewport(FramebufferSize{glyph->bearing()});
-                    auto ascender_vp = view.size_to_viewport(FramebufferPixels{ascender});
-                    auto glyph_size = view.size_to_viewport(FramebufferSize{glyph->size()});
+                    auto bearing = FramebufferSize{glyph->bearing()};
+                    auto ascender_vp = FramebufferPixels{ascender};
+                    auto glyph_size = FramebufferSize{glyph->size()};
                     const auto scale = cell_size.y / glyph_size.y;
                     term.m_emoji_sprites.add_sprite({
                             pen.x + bearing.x * scale,
@@ -1018,7 +1018,7 @@ void TextTerminal::update(View& view, State state)
 
         private:
             TextTerminal& term;
-            ViewportCoords& pen;
+            FramebufferCoords& pen;
             size_t& column;
             text::Font& font;
             text::Font& emoji_font;
@@ -1026,14 +1026,13 @@ void TextTerminal::update(View& view, State state)
             Color8bit m_fg = 7;
             Color8bit m_bg = 0;
             Mode m_mode = Mode::Normal;
-            View& view;
-        } line_renderer(*this, pen, column, font, emoji_font, view);
+        } line_renderer(*this, pen, column, font, emoji_font);
 
         line.render(line_renderer);
 
         // draw rest of blanked line
         if (line.is_blanked()) {
-            ViewportRect rect {
+            FramebufferRect rect {
                     pen.x, pen.y,
                     m_cell_size.x * (m_cells.x - column), m_cell_size.y };
             m_boxes.add_rectangle(rect);
@@ -1041,7 +1040,7 @@ void TextTerminal::update(View& view, State state)
 
         // draw rest of blanked page
         if (line.is_page_blanked()) {
-            ViewportRect rect {
+            FramebufferRect rect {
                     0, pen.y + m_cell_size.y,
                     m_cell_size.x * m_cells.x, m_cell_size.y * (m_cells.y - row - 1) };
             m_boxes.add_rectangle(rect);

--- a/src/xci/widgets/TextTerminal.h
+++ b/src/xci/widgets/TextTerminal.h
@@ -1,7 +1,7 @@
 // TextTerminal.h created on 2018-07-19 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_WIDGETS_TEXTTERMINAL_H
@@ -23,6 +23,10 @@
 namespace xci::widgets {
 
 using graphics::FramebufferPixels;
+using graphics::FramebufferSize;
+using graphics::FramebufferRect;
+using graphics::VariRect;
+using namespace graphics::unit_literals;
 
 
 // Gory bits...
@@ -275,8 +279,8 @@ public:
              graphics::PrimitiveType::TriFans),
       m_shader(renderer.get_shader(graphics::ShaderId::Cursor)) {}
 
-    void update(View& view, const ViewportRect& rect);
-    void draw(View& view, const ViewportCoords& pos);
+    void update(View& view, const FramebufferRect& rect);
+    void draw(View& view, VariCoords pos);
 
 private:
     graphics::Primitives m_quad;
@@ -297,7 +301,7 @@ public:
 
     /// Set font size and font scaling mode:
     /// \param size     size in viewport units
-    void set_font_size(ViewportUnits size);
+    void set_font_size(VariUnits size);
 
     /// Set requested terminal size in cells (i.e. do not scale the number of cells
     /// according to widget size - keep it fixed)
@@ -419,8 +423,8 @@ private:
     static constexpr double c_scroll_end = std::numeric_limits<double>::infinity();
 
     FramebufferPixels m_font_size = 0;
-    ViewportUnits m_font_size_requested {14.0};
-    ViewportSize m_cell_size;
+    VariUnits m_font_size_requested { 14_px };
+    FramebufferSize m_cell_size;
     core::Vec2u m_cells = {80, 25};  // rows, columns
     bool m_resize_cells = true;
     std::unique_ptr<terminal::Buffer> m_buffer = std::make_unique<terminal::Buffer>();

--- a/src/xci/widgets/Widget.cpp
+++ b/src/xci/widgets/Widget.cpp
@@ -1,7 +1,7 @@
 // Widget.cpp created on 2018-04-23 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Widget.h"
@@ -14,6 +14,30 @@ namespace xci::widgets {
 
 using namespace xci::graphics;
 using ranges::cpp20::any_of;
+
+
+void Widget::set_position(const VariCoords& pos)
+{
+    m_position_request = pos;
+    if (pos.x.type() == VariUnits::Framebuffer && pos.y.type() == VariUnits::Framebuffer)
+        m_position = {pos.x.framebuffer(), pos.y.framebuffer()};
+}
+
+
+void Widget::set_size(const VariSize& size)
+{
+    m_size_request = size;
+    if (size.x.type() == VariUnits::Framebuffer && size.y.type() == VariUnits::Framebuffer)
+        m_size = {size.x.framebuffer(), size.y.framebuffer()};
+}
+
+
+void Widget::resize(View& view)
+{
+    m_position = view.to_fb(m_position_request);
+    m_size = view.to_fb(m_size_request);
+}
+
 
 void Widget::partial_dump(std::ostream& stream, const std::string& nl_prefix)
 {
@@ -31,7 +55,7 @@ void Composite::add(Widget& child)
 }
 
 
-bool Composite::contains(const ViewportCoords& point) const
+bool Composite::contains(FramebufferCoords point) const
 {
     return any_of(m_child, [&point](const Widget* child){ return child->contains(point); });
 }
@@ -39,6 +63,7 @@ bool Composite::contains(const ViewportCoords& point) const
 
 void Composite::resize(View& view)
 {
+    Widget::resize(view);
     for (auto& child : m_child)
         child->resize(view);
 }
@@ -118,7 +143,7 @@ void Composite::scroll_event(View& view, const ScrollEvent& ev)
 }
 
 
-bool Composite::click_focus(View& view, ViewportCoords pos)
+bool Composite::click_focus(View& view, FramebufferCoords pos)
 {
     bool handled = false;
     auto* original_focus = m_focus;

--- a/src/xci/widgets/Widget.cpp
+++ b/src/xci/widgets/Widget.cpp
@@ -82,12 +82,11 @@ void Composite::update(View& view, State state)
 
 void Composite::draw(View& view)
 {
-    view.push_offset(position());
+    auto pop_offset = view.push_offset(position());
     for (auto& child : m_child) {
         if (!child->is_hidden())
             child->draw(view);
     }
-    view.pop_offset();
 }
 
 
@@ -113,25 +112,22 @@ void Composite::char_event(View& view, const CharEvent& ev)
 
 void Composite::mouse_pos_event(View& view, const MousePosEvent& ev)
 {
-    view.push_offset(position());
+    auto pop_offset = view.push_offset(position());
     for (auto& child : m_child)
         child->mouse_pos_event(view, ev);
-    view.pop_offset();
 }
 
 
 bool Composite::mouse_button_event(View& view, const MouseBtnEvent& ev)
 {
-    view.push_offset(position());
-    bool handled = false;
+    auto pop_offset = view.push_offset(position());
     for (auto& child : m_child) {
         // Propagate the event
-        handled = child->mouse_button_event(view, ev);
+        bool handled = child->mouse_button_event(view, ev);
         if (handled)
-            break;
+            return true;
     }
-    view.pop_offset();
-    return handled;
+    return false;
 }
 
 

--- a/src/xci/widgets/Widget.h
+++ b/src/xci/widgets/Widget.h
@@ -1,7 +1,7 @@
 // Widget.h created on 2018-04-23 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_WIDGETS_WIDGET_H
@@ -22,10 +22,13 @@ using graphics::CharEvent;
 using graphics::MousePosEvent;
 using graphics::MouseBtnEvent;
 using graphics::ScrollEvent;
-using graphics::ViewportUnits;
-using graphics::ViewportCoords;
-using graphics::ViewportSize;
-using graphics::ViewportRect;
+using graphics::VariUnits;
+using graphics::VariCoords;
+using graphics::VariSize;
+using graphics::FramebufferPixels;
+using graphics::FramebufferCoords;
+using graphics::FramebufferSize;
+using graphics::FramebufferRect;
 
 
 struct State {
@@ -41,17 +44,17 @@ public:
     Theme& theme() const { return m_theme; }
 
     // Set position of widget, relative to the parent
-    void set_position(const ViewportCoords& pos) { m_position = pos; }
-    const ViewportCoords& position() const { return m_position; }
+    void set_position(const VariCoords& pos);
+    const FramebufferCoords& position() const { return m_position; }
 
     // Set size of widget.
     // This may not be respected by actual implementation,
     // but it determines space taken in layout.
-    void set_size(const ViewportSize& size) { m_size = size; }
-    const ViewportSize& size() const { return m_size; }
+    void set_size(const VariSize& size);
+    const FramebufferSize& size() const { return m_size; }
 
-    ViewportRect aabb() const { return {m_position, m_size}; }
-    ViewportUnits baseline() const { return m_baseline; }
+    FramebufferRect aabb() const { return {m_position, m_size}; }
+    FramebufferPixels baseline() const { return m_baseline; }
 
     // Accept keyboard focus by cycling with tab key
     void set_tab_focusable(bool enabled) { m_tab_focusable = enabled; }
@@ -70,12 +73,12 @@ public:
     bool is_hidden() const { return m_hidden; }
 
     // Test if point is contained inside widget area
-    virtual bool contains(const ViewportCoords& point) const { return aabb().contains(point); }
+    virtual bool contains(FramebufferCoords point) const { return aabb().contains(point); }
 
     // Events need to be injected into root widget.
     // This can be set up using Bind helper or manually by calling these methods.
 
-    virtual void resize(View& view) {}
+    virtual void resize(View& view);
     virtual void update(View& view, State state) {}
     virtual void draw(View& view) = 0;
     virtual bool key_event(View& view, const KeyEvent& ev) { return false; }
@@ -83,7 +86,7 @@ public:
     virtual void mouse_pos_event(View& view, const MousePosEvent& ev) {}
     virtual bool mouse_button_event(View& view, const MouseBtnEvent& ev) { return false; }
     virtual void scroll_event(View& view, const ScrollEvent& ev) {}
-    virtual bool click_focus(View& view, ViewportCoords pos) { return is_click_focusable() && contains(pos); }
+    virtual bool click_focus(View& view, FramebufferCoords pos) { return is_click_focusable() && contains(pos); }
     virtual bool tab_focus(View& view, int& step) { return is_tab_focusable(); }
 
     // Debug dump
@@ -91,13 +94,15 @@ public:
     virtual void partial_dump(std::ostream& stream, const std::string& nl_prefix);
 
 protected:
-    void set_baseline(ViewportUnits baseline) { m_baseline = baseline; }
+    void set_baseline(FramebufferPixels baseline) { m_baseline = baseline; }
 
 private:
     Theme& m_theme;
-    ViewportCoords m_position;
-    ViewportSize m_size;
-    ViewportUnits m_baseline = 0;
+    VariCoords m_position_request;
+    VariSize m_size_request;
+    FramebufferCoords m_position;
+    FramebufferSize m_size;
+    FramebufferPixels m_baseline = 0;
 
     // Flags
     bool m_tab_focusable : 1 = false;
@@ -119,7 +124,7 @@ public:
     Widget* focus() const { return m_focus; }
 
     // impl Widget
-    bool contains(const ViewportCoords& point) const override;
+    bool contains(FramebufferCoords point) const override;
 
     void resize(View& view) override;
     void update(View& view, State state) override;
@@ -129,7 +134,7 @@ public:
     void mouse_pos_event(View& view, const MousePosEvent& ev) override;
     bool mouse_button_event(View& view, const MouseBtnEvent& ev) override;
     void scroll_event(View& view, const ScrollEvent& ev) override;
-    bool click_focus(View& view, ViewportCoords pos) override;
+    bool click_focus(View& view, FramebufferCoords pos) override;
     bool tab_focus(View& view, int& step) override;
 
     // Debug dump

--- a/tests/test_graphics.cpp
+++ b/tests/test_graphics.cpp
@@ -7,8 +7,10 @@
 #include <catch2/catch.hpp>
 
 #include <xci/graphics/Color.h>
+#include <xci/graphics/View.h>
 
 using namespace xci::graphics;
+using namespace xci::graphics::unit_literals;
 
 
 TEST_CASE( "Float colors", "[Color]" )
@@ -30,4 +32,38 @@ TEST_CASE( "Indexed colors", "[Color]" )
     CHECK( Color(232) == Color(8, 8, 8) );
     CHECK( Color(254) == Color(228, 228, 228) );
     CHECK( Color(255) == Color(238, 238, 238) );
+}
+
+
+TEST_CASE( "Variant units", "[VariUnits]" )
+{
+    // Type is encoded in upper bits
+    CHECK( VariUnits(0_fb).type() == VariUnits::Framebuffer );
+    CHECK( VariUnits(0_px).type() == VariUnits::Screen );
+    CHECK( VariUnits(0_vp).type() == VariUnits::Viewport );
+    CHECK( VariUnits(1_fb).type() == VariUnits::Framebuffer );
+    CHECK( VariUnits(2_px).type() == VariUnits::Screen );
+    CHECK( VariUnits(3_vp).type() == VariUnits::Viewport );
+    CHECK( VariUnits(-1_fb).type() == VariUnits::Framebuffer );
+    CHECK( VariUnits(-2_px).type() == VariUnits::Screen );
+    CHECK( VariUnits(-3_vp).type() == VariUnits::Viewport );
+
+    // Value is preserved
+    CHECK( VariUnits(0_fb).framebuffer() == 0_fb );
+    CHECK( VariUnits(0_px).screen() == 0_px );
+    CHECK( VariUnits(0_vp).viewport() == 0_vp );
+    CHECK( VariUnits(4_fb).framebuffer() == 4_fb );
+    CHECK( VariUnits(5_px).screen() == 5_px );
+    CHECK( VariUnits(6_vp).viewport() == 6_vp );
+    CHECK( VariUnits(-4_fb).framebuffer() == -4_fb );
+    CHECK( VariUnits(-5_px).screen() == -5_px );
+    CHECK( VariUnits(-6_vp).viewport() == -6_vp );
+
+    // Limits (overflow is asserted, UB in release)
+    CHECK( VariUnits(524287.95_fb).raw_storage() == 0x1fffffc0 );
+    CHECK( VariUnits(-524287.95_fb).raw_storage() == -0x1fffffc0 );
+    CHECK( VariUnits(524287.95_px).raw_storage() == 0x3fffffc0 );
+    CHECK( VariUnits(-524287.95_px).raw_storage() == -0x3fffffc0 );
+    CHECK( VariUnits(15.9999995_vp).raw_storage() == 0x7fffffc0 );
+    CHECK( VariUnits(-15.9999999_vp).raw_storage() == int32_t(-0x80000000) );
 }

--- a/tests/test_graphics.cpp
+++ b/tests/test_graphics.cpp
@@ -61,9 +61,9 @@ TEST_CASE( "Variant units", "[VariUnits]" )
 
     // Limits (overflow is asserted, UB in release)
     CHECK( VariUnits(524287.95_fb).raw_storage() == 0x1fffffc0 );
-    CHECK( VariUnits(-524287.95_fb).raw_storage() == -0x1fffffc0 );
+    CHECK( VariUnits(-524287.99_fb).raw_storage() == -0x20000000 );
     CHECK( VariUnits(524287.95_px).raw_storage() == 0x3fffffc0 );
-    CHECK( VariUnits(-524287.95_px).raw_storage() == -0x3fffffc0 );
-    CHECK( VariUnits(15.9999995_vp).raw_storage() == 0x7fffffc0 );
-    CHECK( VariUnits(-15.9999999_vp).raw_storage() == int32_t(-0x80000000) );
+    CHECK( VariUnits(-524287.99_px).raw_storage() == -0x40000000 );
+    CHECK( VariUnits(16383.9995_vp).raw_storage() == 0x7fffffc0 );
+    CHECK( VariUnits(-16383.9999_vp).raw_storage() == int32_t(-0x80000000) );
 }

--- a/xcikit-config.cmake.in
+++ b/xcikit-config.cmake.in
@@ -1,5 +1,6 @@
 @PACKAGE_INIT@
 
+set_and_check(XCI_PACKAGE_DIR "@PACKAGE_XCI_PACKAGE_DIR@")
 set_and_check(XCI_INCLUDE_DIRS "@PACKAGE_XCI_INCLUDE_DIRS@")
 
 # Dependencies
@@ -10,9 +11,16 @@ include(CMakeFindDependencyMacro)
 find_dependency(Threads)
 find_dependency(fmt)
 find_dependency(pegtl 3.2.0)
+find_dependency(range-v3)
 
 if (@XCI_GRAPHICS@)
+    find_dependency(glfw3 3.2)
     find_dependency(Vulkan)
+endif()
+
+if (@XCI_TEXT@)
+    find_dependency(Freetype)
+    find_dependency(harfbuzz)
 endif()
 
 if (@XCI_WITH_ZIP@)


### PR DESCRIPTION
`VariUnits` are a kind of variant type that can contain `FramebufferPixels` of `ScreenPixels` or `ViewportUnits` (all floats). Any of these values is enocoded in 4 bytes (int32). Bits 1, 2 (0 is sign) distinguish which type is contained, the value itself is encoded as fixed point decimal. The value ranges are still quite generous.

Also, switched underlying unit to `FramebufferPixels`, i.e. all units are eventually converted to framebuffer pixels, and then to Vulkan viewport units via projection matrix. It doesn't matter much when drawing triangles, but helps to avoid unnecessary conversions when placing text glyphs, because all font measures are already in framebuffer pixels.

Also, changed scale of `ViewportUnits` to 100 (was 2.0), to make them closer to CSS (they're basically the CSS `vmin` relative unit, i.e. 1% of smaller viewport dimension).