### PR TITLE
[script] deduplicate StructItem symbols

### DIFF
--- a/src/xci/script/Compiler.cpp
+++ b/src/xci/script/Compiler.cpp
@@ -391,9 +391,7 @@ public:
                 UNREACHABLE;
         }
         // if it's function object, execute it
-        if (sym.type() != Symbol::Function
-        &&  sym.type() != Symbol::Method
-        &&  sym.is_callable()) {
+        if (sym.type() == Symbol::Nonlocal && sym.is_callable()) {
             code().add_opcode(Opcode::Execute);
         }
     }

--- a/src/xci/script/Module.cpp
+++ b/src/xci/script/Module.cpp
@@ -106,8 +106,11 @@ Index Module::add_type(TypeInfo type_info)
     auto idx = find_type(type_info);
     if (idx != no_index) {
         // Replace the placeholder used for named type (contains Unknown ti).
-        if (type_info.is_named())
+        if (type_info.is_named()) {
+            assert(m_types[idx].named_type().type_info.is_unknown()
+                || m_types[idx] == type_info);
             m_types[idx] = std::move(type_info);
+        }
         return idx;
     }
 

--- a/src/xci/script/SymbolTable.h
+++ b/src/xci/script/SymbolTable.h
@@ -95,6 +95,8 @@ public:
             : m_name(ref->name()), m_type(type), m_index(idx),
               m_depth(depth), m_ref(ref) {}
 
+    bool operator==(const Symbol&) const = default;
+
     const std::string& name() const { return m_name; }
     Type type() const { return m_type; }
     Index index() const { return m_index; }
@@ -177,6 +179,7 @@ public:
     const Symbol& get(Index idx) const;
 
     // find symbol in this table
+    SymbolPointer find(const Symbol& symbol);
     SymbolPointer find_by_name(std::string_view name);
     SymbolPointer find_last_of(const std::string& name, Symbol::Type type);
     SymbolPointer find_last_of(Symbol::Type type);

--- a/src/xci/script/SymbolTable.h
+++ b/src/xci/script/SymbolTable.h
@@ -51,7 +51,7 @@ public:
     }
 
 private:
-    SymbolTable* m_symtab = nullptr;  // owning table
+    SymbolTable* m_symtab = nullptr;   // owning table
     Index m_symidx = no_index;         // index of item in the table
 };
 

--- a/src/xci/script/ast/resolve_symbols.cpp
+++ b/src/xci/script/ast/resolve_symbols.cpp
@@ -443,8 +443,7 @@ private:
         }
         // imported modules
         for (auto i = Index(module().num_imported_modules() - 1); i != Index(-1); --i) {
-            auto symptr = module().get_imported_module(
-                    i).symtab().find_last_of(name, type);
+            auto symptr = module().get_imported_module(i).symtab().find_last_of(name, type);
             if (symptr)
                 return symptr;
         }

--- a/src/xci/script/ast/resolve_types.cpp
+++ b/src/xci/script/ast/resolve_types.cpp
@@ -699,6 +699,7 @@ public:
                         return;
                 }
                 m_function.set_nonlocal(sym.index(), TypeInfo{m_value_type});
+                v.identifier.symbol->set_callable(m_value_type.is_callable());
                 break;
             }
             case Symbol::Parameter:
@@ -740,10 +741,6 @@ public:
             case Symbol::Unresolved:
                 UNREACHABLE;
         }
-//        if (sym.type() == Symbol::Function)
-//            m_value_type = m_value_type.effective_type();
-        // FIXME: remove, this writes to builtin etc.
-        v.identifier.symbol->set_callable(m_value_type.is_callable());
     }
 
     void visit(ast::Call& v) override {


### PR DESCRIPTION
This created two sets of `StructItem` symbols - second one for the right-hand side of the assignment (anonymous struct initializer):

```
type MyStruct = (name:String, age:Int, valid:Bool)
a:MyStruct = (name="hello", age=42, valid=true)
```

Now the second set is not created, instead previously created symbols are referenced. Deduplication is allowed only when the symbols are of type `StructItem` and have the same attributes.