### PR TITLE
[script] Void type = empty tuple

### DIFF
--- a/docs/script/syntax.adoc
+++ b/docs/script/syntax.adoc
@@ -9,7 +9,7 @@ endif::[]
 
 = Fire Script
 
-*_Language description, v0.8_*
+*_Language description, v0.9_*
 
 toc::[]
 
@@ -59,10 +59,12 @@ b'@'       // byte / ASCII character
 b"lava"    // bytes (ASCII string)
 """abc"""  // raw string (here doc)
 b"""abc""" // raw bytes
+("abc",42) // tuple
 [1, 2, 3]  // list
 []:[Byte]  // empty list (type can be specified or inferred from context)
-{}         // empty block, effectively Void
-void       // empty statement, returns Void -> noop
+{}         // empty block, has type () -> () (no parameters, no return value)
+()         // empty tuple (value of zero size)
+void       // alias of ()
 ----
 
 The raw string can be multi-line. It has a few special rules:
@@ -126,7 +128,7 @@ l = """
 [source,fire]
 ----
 // define some names in a scope:
-{ a = 1; b = 2 }    // the whole expression evaluates to `void`
+{ a = 1; b = 2 }    // the whole expression evaluates to ()
 a                   // ERROR - `a` is not defined in outer scope
 
 // block returns `a`, `c` evaluates to `1`
@@ -385,8 +387,8 @@ Block is a function with zero arguments:
 
 [source,fire]
 ----
-block1 = { c = add2 a b; }    // returns c (the semicolon is not important)
-block2 = { c = add2 a b; void }  // returns `void`
+block1 = { c = add2 a b; c }    // returns closure c
+block2 = { c = add2 a b }       // returns ()
 block1  // evaluate the block (actually, it might have been evaluated above - that's up to compiler)
 block3 = { a + b }      // block with free variables: a, b
 block3      // the value is still { a + b } - variables are not bound, cannot be evaluated
@@ -735,6 +737,8 @@ catch ex:T
 
 == Types
 
+=== Built-in types
+
 Primitive types:
 
 [source,fire]
@@ -757,23 +761,24 @@ b"abc"              // [Byte]
 [10b, 11b, 13b]     // [Byte]         -- equivalent to the "bytes" literal
 "Hello."            // String         -- UTF-8 string
 ['a', 'b', 'c']     // [Char]         -- compatible with String, but not the same
-("Hello", 33)       // (String, Int)  -- a tuple
 [1, 2, 3]           // [Int]          -- a list
+("Hello", 33)       // (String, Int)  -- a tuple
+()                  // () aka Void    -- empty tuple
 ----
 
 The type of value is inferred from the literal. Assigning literal of a type with
-smaller range is fine. Assigning a value of bigger range is find if it fits,
-compile-time error otherwise.
+smaller range is fine. Assigning a value of bigger range is only fine if it fits,
+otherwise it's a compile-time error.
 
 [source,fire]
 ----
-ok = true       // inferred type Bool
-c = 'a'         // inferred type Char
-byte = 27b      // inferred type Byte
-b1:Byte = 12    // ok
-b2:Byte = 300   // error
-b3 = c          // error, not a literal, must be casted explicitly
-b4 = c:Byte     // cast ok, value clipped
+ok = true           // inferred type Bool
+c = 'a'             // inferred type Char
+byte = 27b          // inferred type Byte
+b1:Byte = 12        // ok
+b2:Byte = 300       // error
+b3:Byte = c         // error, not a literal, must be casted explicitly
+b4:Byte = c:Byte    // cast ok, value clipped
 ----
 
 Strings and lists have the same interface and can be handled universally
@@ -782,6 +787,22 @@ than String: it stores 32bit characters, allowing constant-time indexing,
 but taking more space. String is UTF-8 encoded, random access
 is slower (linear-time), but it takes less space.
 
+==== Void type
+
+[source,fire]
+----
+_0 ? v:() = ()
+_1 ? .d v
+Function v: () -> ()
+----
+
+A special case of the tuple type is an empty tuple `()`, also known as `Void`.
+A value of this type, which is also written as `()` (alias `void`), doesn't carry any data.
+A function taking `()` as input won't pull anything from data stack.
+A function returning `()` doesn't push any data on the stack.
+The size of the value is effectively zero, so the value doesn't exist at all.
+It's only known to the compiler for the purpose of type checking.
+
 === User-defined types
 
 User-defined types are made by giving a name to a type, or to a composition of types.
@@ -789,13 +810,14 @@ All type names must begin with uppercase letter (this is enforced by the compile
 
 [source,fire]
 ----
+type MyVoid = ()     // empty tuple => Void
 type MyType = Int    // make new type by giving other type a new name
 type MyTuple = (String, Int)
 type MyStruct = (name:String, age:Int)    // struct (a tuple with named fields)
 type MyBool = false | true   // enum
 type MyUnion = Int | String | Void   // tagged union
 type MyVariant = int Int | string String | none   // tagged union with explicit names
-type MyOptional T = some T | void   // generic type (a kind?)
+type MyOptional T = some T | none   // generic type (a kind?)
 type MyOptionalInt = MyOptional Int   // instance of the generic type
 type MyFunction = [Int] Int -> Int
 ----

--- a/src/xci/script/Builtin.cpp
+++ b/src/xci/script/Builtin.cpp
@@ -49,7 +49,7 @@ const char* builtin::op_to_function_name(ast::Operator::Op op)
 
 BuiltinModule::BuiltinModule(ModuleManager& module_manager) : Module(module_manager, "builtin")
 {
-    symtab().add({"void", Symbol::Value, add_value(TypedValue{value::Void()})});
+    symtab().add({"void", Symbol::Value, add_value(TypedValue{ti_void()})});
     symtab().add({"false", Symbol::Value, add_value(TypedValue{value::Bool(false)})});
     symtab().add({"true", Symbol::Value, add_value(TypedValue{value::Bool(true)})});
     add_intrinsics();

--- a/src/xci/script/Module.cpp
+++ b/src/xci/script/Module.cpp
@@ -223,7 +223,7 @@ bool Module::save_to_file(const std::string& filename)
 {
     std::ofstream f(filename, std::ios::binary);
     xci::data::BinaryWriter writer(f, true);
-    writer(m_modules)(m_values)(m_symtab)(m_functions);
+    writer(m_modules)(m_values)(m_symtab)(m_functions);  // NOLINT(clang-analyzer-core.uninitialized.UndefReturn) - https://github.com/boostorg/pfr/issues/91
     return !f.fail();
 }
 

--- a/src/xci/script/NativeDelegate.h
+++ b/src/xci/script/NativeDelegate.h
@@ -67,7 +67,7 @@ namespace native {
 
 template<class T>
 typename std::enable_if_t<std::is_void_v<T>, TypeInfo>
-make_type_info() { return TypeInfo{Type::Void}; }
+make_type_info() { return TypeInfo{Type::Tuple}; }
 
 template<class T>
 typename std::enable_if_t<std::is_same_v<T, bool>, TypeInfo>
@@ -116,7 +116,7 @@ struct ValueType_s;
 
 template<>
 struct ValueType_s<void> {
-    using type = value::Void;
+    using type = value::Tuple;
 };
 
 template<>

--- a/src/xci/script/Parser.cpp
+++ b/src/xci/script/Parser.cpp
@@ -134,7 +134,7 @@ struct PlainTypeName: seq< TypeName, not_at<SC, one<','>> > {};  // not followed
 struct ListType: if_must< one<'['>, SC, UnsafeType, SC, one<']'> > {};
 struct TupleType: seq< Type, plus<SC, one<','>, SC, Type> > {};
 struct StructItem: seq< Identifier, SC, one<':'>, SC, must<Type> > {};
-struct StructType: seq< StructItem, plus<SC, one<','>, SC, StructItem> > {};
+struct StructType: seq< StructItem, star<SC, one<','>, SC, StructItem> > {};
 struct ParenthesizedType: if_must< one<'('>, SC, UnsafeType, SC, one<')'> > {};
 struct UnsafeType: sor<FunctionType, PlainTypeName, TupleType, StructType, ParenthesizedType, ListType> {};   // usable in context where Type is already expected
 struct Type: sor< ParenthesizedType, ListType, TypeName > {};

--- a/src/xci/script/Parser.cpp
+++ b/src/xci/script/Parser.cpp
@@ -135,7 +135,7 @@ struct ListType: if_must< one<'['>, SC, UnsafeType, SC, one<']'> > {};
 struct TupleType: seq< Type, plus<SC, one<','>, SC, Type> > {};
 struct StructItem: seq< Identifier, SC, one<':'>, SC, must<Type> > {};
 struct StructType: seq< StructItem, star<SC, one<','>, SC, StructItem> > {};
-struct ParenthesizedType: if_must< one<'('>, SC, UnsafeType, SC, one<')'> > {};
+struct ParenthesizedType: if_must< one<'('>, SC, opt<UnsafeType, SC>, one<')'> > {};
 struct UnsafeType: sor<FunctionType, PlainTypeName, TupleType, StructType, ParenthesizedType, ListType> {};   // usable in context where Type is already expected
 struct Type: sor< ParenthesizedType, ListType, TypeName > {};
 
@@ -154,7 +154,7 @@ template<class S> struct Expression: sor< ExprCond, ExprWith, ExprStruct, ExprIn
 struct Variable: seq< Identifier, opt<SC, one<':'>, SC, must<UnsafeType> > > {};
 struct Block: if_must< one<'{'>, NSC, sor< one<'}'>, seq<SepList<Statement>, NSC, one<'}'>> > > {};
 struct Function: sor< Block, if_must< KeywordFun, NSC, FunctionDecl, NSC, Block> > {};
-struct ParenthesizedExpr: if_must< one<'('>, NSC, Expression<NSC>, NSC, one<')'> > {};
+struct ParenthesizedExpr: if_must< one<'('>, NSC, opt<Expression<NSC>, NSC>, one<')'> > {};
 struct ExprPrefix: if_must< PrefixOperator, SC, ExprOperand<SC>, SC > {};
 struct TypeArgs: seq< one<'<'>, Type, one<'>'> > {};
 struct Reference: seq<Identifier, opt<TypeArgs>, not_at<one<'"'>>> {};
@@ -505,6 +505,8 @@ struct Action<ParenthesizedExpr> : change_states< ast::Parenthesized > {
 
     template<typename Input>
     static void success(const Input &in, ast::Parenthesized& parenthesized, std::unique_ptr<ast::Expression>& expr) {
+        if (!parenthesized.expression)
+            parenthesized.expression = std::make_unique<ast::Tuple>();  // "()" => empty tuple (void)
         expr = std::make_unique<ast::Parenthesized>(std::move(parenthesized));
     }
 };
@@ -828,6 +830,8 @@ template<>
 struct Action<Type> : change_states< std::unique_ptr<ast::Type> >  {
     template<typename Input>
     static void apply(const Input &in, std::unique_ptr<ast::Type>& type) {
+        if (!type)
+            type = std::make_unique<ast::TupleType>();  // "()" => empty tuple type (Void)
         type->source_loc.load(in.input(), in.position());
     }
 
@@ -876,6 +880,8 @@ template<>
 struct Action<UnsafeType> : change_states< std::unique_ptr<ast::Type> >  {
     template<typename Input>
     static void apply(const Input &in, std::unique_ptr<ast::Type>& type) {
+        if (!type)
+            type = std::make_unique<ast::TupleType>();  // "()" => empty tuple type (Void)
         type->source_loc.load(in.input(), in.position());
     }
 

--- a/src/xci/script/Stack.cpp
+++ b/src/xci/script/Stack.cpp
@@ -24,7 +24,7 @@ void Stack::push(const Value& v)
 {
     auto size = v.size_on_stack();
     if (size == 0)
-        return;  // Void
+        return;
     if (m_stack_pointer < size) {
         if (grow() < size)
             throw StackOverflow();
@@ -37,8 +37,6 @@ void Stack::push(const Value& v)
 
 Value Stack::pull(const TypeInfo& ti)
 {
-    if (ti.is_void())
-        return Value();
     // create Value with TypeInfo, read contents from stack
     auto value = create_value(ti);
     pop_type(value);

--- a/src/xci/script/TypeInfo.cpp
+++ b/src/xci/script/TypeInfo.cpp
@@ -32,7 +32,6 @@ size_t type_size_on_stack(Type type)
 {
     switch (type) {
         case Type::Unknown:
-        case Type::Void:
         case Type::Tuple:
         case Type::Struct:
         case Type::Named:
@@ -220,7 +219,6 @@ bool is_same_underlying(const TypeInfo& lhs, const TypeInfo& rhs)
         case Type::Unknown:
         case Type::Named:
             return false;
-        case Type::Void:
         case Type::Bool:
         case Type::Byte:
         case Type::Char:
@@ -310,6 +308,18 @@ auto TypeInfo::elem_type() const -> const TypeInfo&
         return named_type().type_info.elem_type();
     assert(m_type == Type::List);
     assert(std::holds_alternative<Subtypes>(m_info));
+    assert(std::get<Subtypes>(m_info).size() == 1);
+    return std::get<Subtypes>(m_info)[0];
+}
+
+
+auto TypeInfo::elem_type() -> TypeInfo&
+{
+    if (m_type == Type::Named)
+        return named_type_ptr()->type_info.elem_type();
+    assert(m_type == Type::List);
+    assert(std::holds_alternative<Subtypes>(m_info));
+    assert(std::get<Subtypes>(m_info).size() == 1);
     return std::get<Subtypes>(m_info)[0];
 }
 
@@ -318,6 +328,16 @@ auto TypeInfo::subtypes() const -> const Subtypes&
 {
     if (m_type == Type::Named)
         return named_type().type_info.subtypes();
+    assert(m_type == Type::Tuple);
+    assert(std::holds_alternative<Subtypes>(m_info));
+    return std::get<Subtypes>(m_info);
+}
+
+
+auto TypeInfo::subtypes() -> Subtypes&
+{
+    if (m_type == Type::Named)
+        return named_type_ptr()->type_info.subtypes();
     assert(m_type == Type::Tuple);
     assert(std::holds_alternative<Subtypes>(m_info));
     return std::get<Subtypes>(m_info);

--- a/src/xci/script/TypeInfo.h
+++ b/src/xci/script/TypeInfo.h
@@ -21,7 +21,6 @@ namespace xci::script {
 
 enum class Type : uint8_t {
     Unknown,    // type not known at this time (might be inferred or generic)
-    Void,       // void type - has no value
 
     // Primitive types
     Bool,
@@ -114,7 +113,8 @@ public:
     bool is_unknown() const { return m_type == Type::Unknown; }
     bool is_named() const { return m_type == Type::Named; }
     bool is_callable() const { return underlying_type() == Type::Function; }
-    bool is_void() const { return underlying_type() == Type::Void; }
+    bool is_void() const { return is_tuple() && subtypes().empty(); }
+    bool is_bool() const { return underlying_type() == Type::Bool; }
     bool is_tuple() const { return underlying_type() == Type::Tuple; }
     bool is_struct() const { return underlying_type() == Type::Struct; }
 
@@ -138,7 +138,9 @@ public:
 
     Var generic_var() const;  // type = Unknown
     const TypeInfo& elem_type() const;  // type = List (Subtypes[0])
+    TypeInfo& elem_type();              // type = List (Subtypes[0])
     const Subtypes& subtypes() const;  // type = Tuple
+    Subtypes& subtypes();              // type = Tuple
     const StructItems& struct_items() const;  // type = Struct
     const TypeInfo* struct_item_by_name(const std::string& name) const;  // type = Struct
     Subtypes struct_or_tuple_subtypes() const;  // type = Tuple | Struct
@@ -289,7 +291,7 @@ struct NamedType {
 // Shortcuts
 
 inline TypeInfo ti_unknown() { return TypeInfo(Type::Unknown); }
-inline TypeInfo ti_void() { return TypeInfo(Type::Void); }
+inline TypeInfo ti_void() { return TypeInfo(TypeInfo::tuple_of, {}); }
 inline TypeInfo ti_bool() { return TypeInfo(Type::Bool); }
 inline TypeInfo ti_byte() { return TypeInfo(Type::Byte); }
 inline TypeInfo ti_char() { return TypeInfo(Type::Char); }

--- a/src/xci/script/ast/fold_const_expr.cpp
+++ b/src/xci/script/ast/fold_const_expr.cpp
@@ -235,7 +235,7 @@ public:
         apply_and_fold(v.expression);
         // cast to Void?
         if (v.to_type.is_void()) {
-            m_const_value = TypedValue(value::Void{});
+            m_const_value = TypedValue(ti_void());
             m_collapsed = make_unique<ast::Literal>(*m_const_value);
             return;
         }

--- a/src/xci/script/ast/resolve_types.cpp
+++ b/src/xci/script/ast/resolve_types.cpp
@@ -716,9 +716,11 @@ public:
                     m_call_args.clear();
                     // __value returns index (Int32)
                     m_value_type = ti_int32();
-                    break;
+                } else {
+                    TypeCheckHelper type_check(std::move(m_type_info));
+                    auto inferred = symtab.module()->get_value(sym.index()).type_info();
+                    m_value_type = type_check.resolve(inferred, v.source_loc);
                 }
-                m_value_type = symtab.module()->get_value(sym.index()).type_info();
                 break;
             case Symbol::TypeName:
             case Symbol::TypeVar:

--- a/src/xci/script/dump.cpp
+++ b/src/xci/script/dump.cpp
@@ -976,7 +976,6 @@ std::ostream& operator<<(std::ostream& os, const TypeInfo& v)
                 return os << type_var_names[var - 1];
             return os << char('S' + var);
         }
-        case Type::Void:        return os << "Void";
         case Type::Bool:        return os << "Bool";
         case Type::Byte:        return os << "Byte";
         case Type::Char:        return os << "Char";
@@ -1047,7 +1046,7 @@ std::ostream& operator<<(std::ostream& os, const Signature& v)
             os << ti << ' ';
         }
     } else {
-        os << "Void ";
+        os << "() ";
     }
     os << "-> ";
     stream_options(os).parenthesize_fun_types = orig_parenthesize_fun_types;

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -296,7 +296,7 @@ TEST_CASE( "Type argument or comparison?", "[script][parser]" )
 
 TEST_CASE( "Value size on stack", "[script][machine]" )
 {
-    CHECK(Value().size_on_stack() == type_size_on_stack(Type::Void));
+    CHECK(Value().size_on_stack() == type_size_on_stack(Type::Unknown));
     CHECK(Value(false).size_on_stack() == type_size_on_stack(Type::Bool));
     CHECK(Value(0).size_on_stack() == type_size_on_stack(Type::Int32));
     CHECK(Value(int64_t{0}).size_on_stack() == type_size_on_stack(Type::Int64));
@@ -525,16 +525,16 @@ TEST_CASE( "Blocks", "[script][interpreter]" )
     CHECK(parse("{{}}") == "{{}}");
 
     // blocks are evaluated and return a value
-    CHECK(interpret("{}") == "");  // empty function (has Void type)
-    CHECK(interpret("{{}}") == "");  // empty function in empty function
-    CHECK(interpret("{};{};{}") == "");  // three empty functions
+    CHECK(interpret("{}") == "()");  // empty function (has Void type)
+    CHECK(interpret("{{}}") == "()");  // empty function in empty function
+    CHECK(interpret("{};{};{}") == "()");  // three empty functions
     CHECK(interpret_std("{1+2}") == "3"); // non-empty
     CHECK(interpret_std("{{{1+2}}}") == "3"); // three wrapped functions, each returns the result of inner one
-    CHECK(interpret_std("{1+2;4;{}}") == "3;4;");  // {} as the last statement changes function result to Void, intermediate results are "invoked"
+    CHECK(interpret_std("{1+2;4;{}}") == "3;4;()");  // {} as the last statement changes function result to Void, intermediate results are "invoked"
     CHECK(interpret_std("x=4; b = 3 + {x+1}; b") == "8");
 
     // blocks can be assigned to a name
-    CHECK(interpret("a = {}; a") == "");  // empty block can be named too, `a` is a named function of Void type
+    CHECK(interpret("a = {}; a") == "()");  // empty block can be named too, `a` is a named function of Void type
     CHECK(interpret_std("b = {1+2}; b") == "3");
     CHECK(interpret("b = { a = 1; a }; b") == "1");
     CHECK(interpret_std("b:Int = {1+2}; b") == "3");
@@ -684,6 +684,15 @@ TEST_CASE( "Generic functions", "[script][interpreter]" )
     CHECK(interpret("f = fun<T> T->T { __noop }; f (f 3)") == "3");
     CHECK(interpret("f = fun<T> T->T { __noop }; 4 .f .f .f") == "4");
     CHECK(interpret("f = fun<T> T->T { __noop }; same = fun<T> x:T -> T { f (f x) }; same 5") == "5");
+    // deducing tuple type
+    CHECK(interpret("fun () -> () { __noop } ()") == "()");
+    CHECK(interpret("fun<T> (T,T) -> (T,T) { __noop } (1,2)") == "(1, 2)");
+    CHECK(interpret("f = fun<T> (T,T) -> (T,T) { __noop }; f (1,2)") == "(1, 2)");
+    //CHECK(interpret("f = fun<Add T> (T,T) -> T { add }; f (1,2)") == "3");
+    // deducing list type
+    CHECK(interpret("fun<T> [T] -> [T] { __noop } [1,2]") == "[1, 2]");
+    CHECK(interpret("len = fun<T> [T] -> UInt { __length __type_id<T> }; len [1,2,3]") == "3U");
+    CHECK(interpret_std("f = fun<T> a:[T] -> T { a!1 }; f [1,2,3]") == "2");
 }
 
 
@@ -708,7 +717,7 @@ TEST_CASE( "Overloaded functions", "[script][interpreter]" )
 
 TEST_CASE( "Lexical scope", "[script][interpreter]" )
 {
-    CHECK(interpret("{a=1; b=2}") == "");
+    CHECK(interpret("{a=1; b=2}") == "()");
     CHECK_THROWS_AS(interpret("{a=1; b=2} a"), UndefinedName);
 
     CHECK(interpret_std("x=1; y = { x + 2 }; y") == "3");
@@ -747,7 +756,8 @@ TEST_CASE( "If-expression", "[script][interpreter]" )
 
 TEST_CASE( "Casting", "[script][interpreter]" )
 {
-    CHECK(interpret_std("\"drop this\":Void") == "");
+    CHECK(interpret_std("\"drop this\":Void") == "()");
+    CHECK(interpret_std("\"drop this\":()") == "()");
     CHECK(interpret_std("\"noop\":String") == "\"noop\"");
     CHECK(interpret_std("42:Int64") == "42L");
     CHECK(interpret_std("42L:Int32") == "42");
@@ -902,7 +912,7 @@ TEST_CASE( "With expression, I/O streams", "[script][interpreter]" )
     // write an actual file
     auto filename = fs::temp_directory_path() / "xci_test_script.txt";
     CHECK(interpret("with (open \""s + escape(filename.string()) + "\" \"w\")\n"
-                    "    write \"this goes to the file\"") == "");
+                    "    write \"this goes to the file\"") == "()");
     CHECK(interpret("with (in=(open \""s + escape(filename.string()) + "\" \"r\"))\n"
                     "    read 9") == "\"this goes\"");
     CHECK(fs::remove(filename));
@@ -927,7 +937,7 @@ TEST_CASE( "Compiler intrinsics", "[script][interpreter]" )
 
 TEST_CASE( "Native to TypeInfo mapping", "[script][native]" )
 {
-    CHECK(native::make_type_info<void>().type() == Type::Void);
+    CHECK(native::make_type_info<void>().is_void());
     CHECK(native::make_type_info<bool>().type() == Type::Bool);
     CHECK(native::make_type_info<uint8_t>().type() == Type::Byte);
     CHECK(native::make_type_info<char>().type() == Type::Char);
@@ -947,7 +957,7 @@ TEST_CASE( "Native to TypeInfo mapping", "[script][native]" )
 
 TEST_CASE( "Native to Value mapping", "[script][native]" )
 {
-    CHECK(native::ValueType<void>().type() == Type::Void);
+    CHECK(native::ValueType<void>().is_void());
     CHECK(native::ValueType<bool>{true}.value() == true);
     CHECK(native::ValueType<byte>(255).value() == 255);
     CHECK(native::ValueType<char>('y').value() == 'y');
@@ -1033,9 +1043,9 @@ TEST_CASE( "Fold const expressions", "[script][optimizer]" )
     CHECK(optimize("f=fun a:Int {a}; f 42") == "/*def*/ f = (fun a:Int -> $R {a});\n42");
 
     // cast to Void eliminates the expression
-    CHECK(optimize("42:Void") == "");
-    CHECK(optimize("{42}:Void") == "");
-    CHECK(optimize("(fun x { x + 1 }):Void") == "");
+    CHECK(optimize("42:Void") == "()");
+    CHECK(optimize("{42}:Void") == "()");
+    CHECK(optimize("(fun x { x + 1 }):Void") == "()");
 
     // cast to the same type is eliminated
     CHECK(optimize("42:Int") == "42");

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -457,7 +457,8 @@ TEST_CASE( "Types", "[script][interpreter]" )
 {
     // each definition can have explicit type
     CHECK(interpret("a:Int = 1 ; a") == "1");
-    CHECK_THROWS_AS(interpret("a:Int = 1.0 ; a"), DefinitionTypeMismatch);
+    CHECK_THROWS_AS(interpret("a:Int = 1.0"), DefinitionTypeMismatch);
+    CHECK_THROWS_AS(interpret("a:Int = true"), DefinitionTypeMismatch);
     CHECK(interpret_std("a:Int = 42; b:Int = a; b") == "42");
     CHECK_THROWS_AS(interpret("a = 42; b:String = a"), FunctionNotFound);
 
@@ -873,7 +874,7 @@ TEST_CASE( "Type classes", "[script][interpreter]" )
                     "instance Ord String { lt = fun a b { string_compare a b < 0 } }; "
                     "\"a\" < \"b\"") == "true");
     // Instantiate type class from another module
-    CHECK(interpret_std("instance Ord Bool { lt = { __less_than 0x11 }; gt = false; le = false; ge = false }; "
+    CHECK(interpret_std("instance Ord Bool { lt = { __less_than 0x11 }; gt = {false}; le = {false}; ge = {false} }; "
                         "false < true; 2 < 1") == "true;false");
 }
 

--- a/tools/fire_script/Highlighter.cpp
+++ b/tools/fire_script/Highlighter.cpp
@@ -145,7 +145,7 @@ struct InvalidCommand: star< not_at< blank >, any > {};
 struct ReplCommand: seq<one<'.'>, sor<ValidCommand, InvalidCommand>, SC, star<PartialExpr, SC>> {};
 
 // Expressions
-struct BracketedExpr: seq< RoundBracketOpen, NSC, Expression, NSC, RoundBracketClose > {};
+struct BracketedExpr: seq< RoundBracketOpen, NSC, opt<Expression, NSC>, RoundBracketClose > {};
 struct List: seq< SquareBracketOpen, NSC, opt<Expression, NSC>, SquareBracketClose > {};
 struct FullyBracketed: sor< BracketedExpr, Block, List > {};
 struct PrimaryExpr: sor< Operator, Literal, Keyword, SpecialVariable, Identifier, TypeName > {};


### PR DESCRIPTION
`void` value and `Void` type are now aliases to `()` value and `()` type

```
_0 ? v:() = ()
_1 ? .d v
Function v: () -> ()
```
