### PR TITLE
[script] refactoring - avoid demangled types in runtime strings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
           build_args: "-DCMAKE_DISABLE_PRECOMPILE_HEADERS=1"
 #        - os: windows-2022
 #          name: "VS 17 / Release"
-#          build_args: ""
+#          build_args: "-DCMAKE_DISABLE_PRECOMPILE_HEADERS=1"
 
     name: ${{ matrix.os }} / ${{ matrix.name }}
 

--- a/src/xci/core/TermCtl.h
+++ b/src/xci/core/TermCtl.h
@@ -1,7 +1,7 @@
 // TermCtl.h created on 2018-07-09 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2020, 2021 Radek Brich
+// Copyright 2018–2022 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_CORE_TERM_H
@@ -59,13 +59,13 @@ public:
     // Following methods are appending the capability codes
     // to a copy of TermCtl instance, which can then be send to stream
 
-    enum class Color {
+    enum class Color: uint8_t {
         Default = 9,
         Black = 0, Red, Green, Yellow, Blue, Magenta, Cyan, White,
         BrightBlack = 10, BrightRed, BrightGreen, BrightYellow,
         BrightBlue, BrightMagenta, BrightCyan, BrightWhite,
     };
-    enum class Mode { Normal,  // reset all attributes
+    enum class Mode: uint8_t { Normal,  // reset all attributes
         Bold, Dim, Italic, Underline, Overline, CrossOut, Frame,
         Blink, Reverse, Hidden,
         NormalIntensity, NoItalic, NoUnderline, NoOverline, NoCrossOut, NoFrame,

--- a/src/xci/script/Compiler.cpp
+++ b/src/xci/script/Compiler.cpp
@@ -607,7 +607,7 @@ private:
         auto& parent_fn = parent_scope.function();
         auto closure_size = parent_fn.raw_size_of_closure();
         // make closure
-        unsigned nl_i = scope.nonlocals().size();
+        auto nl_i = scope.nonlocals().size();
         for (const auto& nl : reverse(scope.nonlocals())) {
             --nl_i;
             const auto& sym = *func.symtab().find_by_index(Symbol::Nonlocal, nl.index);

--- a/src/xci/script/Parser.cpp
+++ b/src/xci/script/Parser.cpp
@@ -166,7 +166,7 @@ struct ExprCondThen: if_must<KeywordThen, NSC, Expression<SC>> {};
 struct ExprCondIf: if_must<KeywordIf, NSC, ExprInfix<NSC>, NSC, ExprCondThen> {};
 struct ExprCondElse: if_must<KeywordElse, NSC, Expression<SC>> {};
 struct ExprCond: seq< plus< ExprCondIf, NSC >, ExprCondElse> {};
-struct ExprWith: if_must< KeywordWith, NSC, ExprArgSafe, NSC, Expression<SC> > {};  // might be parsed as a function, but that wouldn't allow newlines
+struct ExprWith: if_must< KeywordWith, NSC, ExprArgSafe, NSC, Expression<SC> > {};  // could be parsed as a function, but that wouldn't allow newlines
 struct ExprStructItem: seq< Identifier, SC, one<'='>, not_at<one<'='>>, SC, must<ExprArgSafe> > {};
 struct ExprStruct: seq< ExprStructItem, star< SC, one<','>, SC, must<ExprStructItem> > > {};
 

--- a/src/xci/script/Parser.cpp
+++ b/src/xci/script/Parser.cpp
@@ -1274,14 +1274,19 @@ inline bool do_not_trace(std::string_view rule) {
 }
 #endif
 
+using ErrMsg = const std::pair<const char*, std::string_view>;
+
 template< typename Rule >
 struct Control : normal< Rule >
 {
-    static const std::string errmsg;
+    static ErrMsg errmsg;
 
     template< typename Input, typename... States >
     static void raise( const Input& in, States&&... /*unused*/ ) {
-        throw parse_error( errmsg, in );
+        if (!errmsg.second.empty())
+            throw parse_error( errmsg.first + std::string(errmsg.second), in );
+        else
+            throw parse_error( errmsg.first, in );
     }
 
 #ifdef XCI_SCRIPT_PARSER_TRACE
@@ -1369,23 +1374,37 @@ struct Control : normal< Rule >
 #endif
 };
 
-template<> const std::string Control<eof>::errmsg = "invalid syntax";
-template<> const std::string Control<Expression<SC>>::errmsg = "expected expression";
-template<> const std::string Control<Expression<NSC>>::errmsg = "expected expression";
-template<> const std::string Control<DeclParams>::errmsg = "expected function parameter declaration";
-template<> const std::string Control<ExprInfixRight<SC>>::errmsg = "expected infix operator";
-template<> const std::string Control<ExprInfixRight<NSC>>::errmsg = "expected infix operator";
-template<> const std::string Control<Variable>::errmsg = "expected variable name";
-template<> const std::string Control<UnsafeType>::errmsg = "expected type";
-template<> const std::string Control<Type>::errmsg = "expected type";
-template<> const std::string Control<TypeName>::errmsg = "expected type name";
-template<> const std::string Control<StringContent>::errmsg = "unclosed string literal";
-template<> const std::string Control<RawStringContent>::errmsg = "unclosed raw string literal";
+template<> ErrMsg Control<eof>::errmsg = {"invalid syntax", {}};
+template<> ErrMsg Control<until< string<'*', '/'>, any >>::errmsg = {"unterminated comment", {}};
+template<> ErrMsg Control<one<']'>>::errmsg = {"expected ']'", {}};
+template<> ErrMsg Control<one<')'>>::errmsg = {"expected ')'", {}};
+template<> ErrMsg Control<one<'>'>>::errmsg = {"expected '>'", {}};
+template<> ErrMsg Control<one<'{'>>::errmsg = {"expected '{'", {}};
+template<> ErrMsg Control<one<'}'>>::errmsg = {"expected '}'", {}};
+template<> ErrMsg Control<one<'='>>::errmsg = {"expected '='", {}};
+template<> ErrMsg Control<one<'\''>>::errmsg = {"expected '\''", {}};
+template<> ErrMsg Control<RS>::errmsg = {"expected a whitespace character", {}};
+template<> ErrMsg Control<SC>::errmsg = {"expected a whitespace character", {}};
+template<> ErrMsg Control<NSC>::errmsg = {"expected a whitespace character", {}};
+template<> ErrMsg Control<until<eolf>>::errmsg = {"unterminated comment", {}};
+template<> ErrMsg Control<Expression<SC>>::errmsg = {"expected expression", {}};
+template<> ErrMsg Control<Expression<NSC>>::errmsg = {"expected expression", {}};
+template<> ErrMsg Control<DeclParams>::errmsg = {"expected function parameter declaration", {}};
+template<> ErrMsg Control<ExprInfixRight<SC>>::errmsg = {"expected infix operator", {}};
+template<> ErrMsg Control<ExprInfixRight<NSC>>::errmsg = {"expected infix operator", {}};
+template<> ErrMsg Control<Variable>::errmsg = {"expected variable name", {}};
+template<> ErrMsg Control<UnsafeType>::errmsg = {"expected type", {}};
+template<> ErrMsg Control<Type>::errmsg = {"expected type", {}};
+template<> ErrMsg Control<TypeName>::errmsg = {"expected type name", {}};
+template<> ErrMsg Control<StringContent>::errmsg = {"unclosed string literal", {}};
+template<> ErrMsg Control<RawStringContent>::errmsg = {"unclosed raw string literal", {}};
 
 // default message
-template< typename T >
-const std::string Control< T >::errmsg = "parse error matching " + std::string(demangle< T >());
-
+#ifndef NDEBUG
+template< typename T > ErrMsg Control< T >::errmsg = {"parse error matching ", demangle<T>()};
+#else
+template< typename T > ErrMsg Control< T >::errmsg = {"parse error", {}};
+#endif
 
 // ----------------------------------------------------------------------------
 
@@ -1404,7 +1423,6 @@ void Parser::parse(SourceId src_id, ast::Module& mod)
         tao::pegtl::tracking_mode::eager,
         tao::pegtl::eol::lf_crlf,
         SourceRef>
-    //SourceRef{m_source_manager, src_id}
     in(src.data(), src.size(), SourceRef{m_source_manager, src_id});
 
     try {

--- a/src/xci/script/Stack.h
+++ b/src/xci/script/Stack.h
@@ -12,7 +12,7 @@
 #include <xci/core/container/ChunkedStack.h>
 #include <cstddef>  // byte
 #include <vector>
-#include <iostream>
+#include <ostream>
 
 namespace xci::script {
 

--- a/tools/fire_script/Highlighter.h
+++ b/tools/fire_script/Highlighter.h
@@ -14,6 +14,8 @@
 
 namespace xci::script::tool {
 
+namespace parser { struct Node; }
+
 
 class Highlighter {
 public:
@@ -35,7 +37,7 @@ public:
 
 private:
     void switch_color(const HighlightColor& from, const HighlightColor& to);
-    HighlightColor highlight_node(const tao::pegtl::parse_tree::node& node,
+    HighlightColor highlight_node(const parser::Node& node,
                                   const HighlightColor& prev_color,
                                   unsigned cursor, bool hl_bracket = false);
 


### PR DESCRIPTION
`strings fire` shows stuff like this:
```
std::string_view tao::pegtl::demangle() [T = xci::script::tool::parser::NSC]
std::string_view tao::pegtl::demangle() [T = tao::pegtl::xdigit]
std::string_view tao::pegtl::demangle() [T = tao::pegtl::opt<tao::pegtl::digit>]
std::string_view tao::pegtl::demangle() [T = tao::pegtl::sor<xci::core::parser::unescape::StringChEscHex, xci::core::parser::unescape::StringChEscOct, xci::core::parser::unescape::StringChEscSingle>]
std::string_view tao::pegtl::demangle() [T = tao::pegtl::sor<xci::script::tool::parser::ReplCommand, xci::script::tool::parser::SepList<xci::script::tool::parser::Statement>, tao::pegtl::success>]
```

It comes from two places:
* parse error message -> keep only in Debug build
* highlighter -> do not use demangled type strings for rule matching, use static types