### PR TITLE
[build] optional dependencies in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ option(XCI_INSTALL_DEVEL "Install headers, CMake config, static libs." ON)
 option(XCI_WITH_TERMINFO "Link with TermInfo and use it for TTY control sequences, instead of builtin sequences." OFF)
 option(XCI_WITH_ZIP "Link xci-core with libzip and use it for ZIP format in VFS." OFF)
 option(XCI_WITH_HYPERSCAN "Hyperscan library is required to build ff tool." OFF)
+option(XCI_WITH_PEGTL "PEGTL library is required to build xci-script." ON)
 
 # negate it for use as option() initial value
 if (EMSCRIPTEN)
@@ -89,16 +90,22 @@ add_subdirectory(third_party)
 find_package(Threads REQUIRED)
 
 # PEGTL
-find_package(pegtl REQUIRED)
+if (XCI_WITH_PEGTL)
+    find_package(pegtl REQUIRED)
+endif()
 
 # range-v3
-find_package(range-v3 REQUIRED)
+if (XCI_SCRIPT OR XCI_GRAPHICS)
+    find_package(range-v3 REQUIRED)
+endif()
 
 # fmtlib
 find_package(fmt REQUIRED)
 
 # magic enum
-find_package(magic_enum REQUIRED)
+if (XCI_DATA)
+    find_package(magic_enum REQUIRED)
+endif()
 
 # Catch
 if (BUILD_TESTING)

--- a/config.h.in
+++ b/config.h.in
@@ -8,7 +8,8 @@
 #cmakedefine XCI_VERSION "@XCI_VERSION@"
 
 // Optional libraries
-#cmakedefine XCI_WITH_TERMINFO
+#cmakedefine01 XCI_WITH_TERMINFO
+#cmakedefine01 XCI_WITH_PEGTL
 
 // Location of share dir (runtime data)
 #cmakedefine XCI_SHARE_DIR "@XCI_SHARE_DIR@"

--- a/src/xci/core/CMakeLists.txt
+++ b/src/xci/core/CMakeLists.txt
@@ -80,8 +80,14 @@ target_include_directories(xci-core
         ${XCI_INCLUDE_DIRS}
     PRIVATE
         $<TARGET_PROPERTY:third_party::widechar_width,INTERFACE_INCLUDE_DIRECTORIES>
-        $<TARGET_PROPERTY:taocpp::pegtl,INTERFACE_INCLUDE_DIRECTORIES>
     )
+
+if (XCI_WITH_PEGTL)
+    target_include_directories(xci-core
+        PRIVATE
+            $<TARGET_PROPERTY:taocpp::pegtl,INTERFACE_INCLUDE_DIRECTORIES>
+        )
+endif()
 
 # Link with tinfo if available
 if (XCI_WITH_TERMINFO)

--- a/src/xci/core/TermCtl.cpp
+++ b/src/xci/core/TermCtl.cpp
@@ -32,7 +32,7 @@
     #include <sys/select.h>
 #endif
 
-#ifdef XCI_WITH_TERMINFO
+#if XCI_WITH_TERMINFO == 1
     #include <term.h>
 #endif
 
@@ -48,7 +48,7 @@ namespace xci::core {
 
 // When building without TInfo, emit ANSI escape sequences directly
 // Note that these need to be macros, to match compiler behaviour with <term.h>
-#ifndef XCI_WITH_TERMINFO
+#if XCI_WITH_TERMINFO == 0
 #define cursor_up               CSI "A"
 #define cursor_down             CSI "B"
 #define cursor_right            CSI "C"
@@ -107,7 +107,7 @@ inline std::string xci_tparm(const char* seq, Args... args) {
 // because the arguments must not be evaluated unless is_initialized() is true
 #define XCI_TERM_APPEND(...) TermCtl(*this, is_tty() ? xci_tparm(__VA_ARGS__) : "")
 
-#ifdef XCI_WITH_TERMINFO
+#if XCI_WITH_TERMINFO == 1
     // delegate to TermInfo
     #define TERM_APPEND(...) TermCtl(*this, is_tty() ? tparm(__VA_ARGS__) : "")
     static unsigned _plus_one(unsigned arg) { return arg; }  // already corrected with Terminfo -> noop
@@ -125,7 +125,7 @@ public:
         return instance()._lookup(input_buffer);
     }
 
-#ifdef XCI_WITH_TERMINFO
+#if XCI_WITH_TERMINFO == 1
     static void populate_terminfo() {
         std::initializer_list<std::pair<const char*, TermCtl::Key>> seqs = {
                 {key_enter, TermCtl::Key::Enter},
@@ -441,7 +441,7 @@ void TermCtl::set_is_tty(IsTty is_tty)
             return;
     }
 
-    #ifdef XCI_WITH_TERMINFO
+    #if XCI_WITH_TERMINFO == 1
     // Setup terminfo
     int err = 0;
     if (setupterm(nullptr, m_fd, &err) != 0)

--- a/src/xci/core/string.cpp
+++ b/src/xci/core/string.cpp
@@ -5,7 +5,11 @@
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "string.h"
+
+#if XCI_WITH_PEGTL == 1
 #include "parser/unescape.h"
+#endif
+
 #include <xci/core/log.h>
 
 #include <fmt/core.h>
@@ -149,6 +153,7 @@ std::string escape(string_view str, bool extended, bool utf8)
 }
 
 
+#if XCI_WITH_PEGTL == 1
 std::string unescape(string_view str)
 {
     using namespace parser::unescape;
@@ -171,6 +176,7 @@ std::string unescape(string_view str)
     result.shrink_to_fit();
     return result;
 }
+#endif
 
 
 std::string to_lower(std::string_view str)

--- a/src/xci/core/string.h
+++ b/src/xci/core/string.h
@@ -7,6 +7,8 @@
 #ifndef XCI_CORE_STRING_H
 #define XCI_CORE_STRING_H
 
+#include <xci/config.h>
+
 #include <string_view>
 #include <string>
 #include <vector>
@@ -114,11 +116,13 @@ void strip(S& str) { lstrip(str); rstrip(str); }
 std::string escape(std::string_view str, bool extended = false, bool utf8 = false);
 inline std::string escape_utf8(std::string_view str, bool extended = false) { return escape(str, extended, true); }
 
+#if XCI_WITH_PEGTL == 1
 // Unescape (expand) C escape sequences (i.e. "\\n" -> "\n")
 // This expects the input is well-formatted:
 // - a trailing backslash is just ignored
 // - unknown escape sequence (e.g. "\\J") is expanded to literal character ("J")
 std::string unescape(std::string_view str);
+#endif
 
 // Convert string to lower case
 std::string to_lower(std::string_view str);

--- a/tools/find_file/README.md
+++ b/tools/find_file/README.md
@@ -56,3 +56,19 @@ Not planned:
    - This would add a ton of complexity with questionable profit. If you want to hide
      build products from search tools like `ff`, then consider building into a hidden directory
      like `.build`.
+
+
+Build
+-----
+
+Configure cmake to build just `ff` tool + necessary libs (run from repo root, not tools subdirectory):
+
+```bash
+mkdir build; cd build
+cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release --install-prefix $PWD/artifacts \
+  -DXCI_WITH_HYPERSCAN=ON -DXCI_WITH_PEGTL=OFF \
+  -DXCI_GRAPHICS=OFF -DXCI_DATA=OFF -DXCI_SCRIPT=OFF -DXCI_TEXT=OFF -DXCI_WIDGETS=OFF \
+  -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_BENCHMARKS=OFF -DXCI_INSTALL_DEVEL=OFF
+```
+
+Note that `ccmake` tool may be more convenient to flip the switches, especially if the above command line becomes outdated.


### PR DESCRIPTION
Do not require PEGTL, range-v3 when building only the `ff` tool.