### PR TITLE
[core] ResourceUsage

### DIFF
--- a/src/xci/core/CMakeLists.txt
+++ b/src/xci/core/CMakeLists.txt
@@ -7,6 +7,8 @@ add_library(xci-core
     file.cpp
     dispatch.cpp
     EditBuffer.cpp
+    EditLine.cpp
+    ResourceUsage.cpp
     FpsCounter.cpp
     log.cpp
     SharedLibrary.cpp
@@ -15,7 +17,6 @@ add_library(xci-core
     rtti.cpp
     TermCtl.cpp
     Vfs.cpp
-    EditLine.cpp
     $<TARGET_OBJECTS:third_party::widechar_width>
     )
 add_library(xcikit::xci-core ALIAS xci-core)

--- a/src/xci/core/ResourceUsage.cpp
+++ b/src/xci/core/ResourceUsage.cpp
@@ -6,19 +6,31 @@
 
 #include "ResourceUsage.h"
 #include <fmt/core.h>
+#include <chrono>
 
 #ifndef _WIN32
-#include <sys/resource.h>
+    #include <sys/resource.h>
+    #include <sys/time.h>
+#else
+    #include <xci/core/bit.h>
+    #include <Windows.h>
+    #include <psapi.h>
 #endif
 
 namespace xci::core {
 
 
-static uint64_t timeval_to_micros(const timeval& tv)
+#ifndef _WIN32
+static uint64_t timeval_to_micros(const struct timeval& tv)
 {
     return tv.tv_sec * 1'000'000 + tv.tv_usec;
 }
-
+#else
+static uint64_t filetime_to_micros(const FILETIME& ft) {
+    // FILETIME is in 100ns
+    return bit_copy<uint64_t>(&ft) / 10;
+}
+#endif
 
 void ResourceUsage::start(const char* name)
 {
@@ -32,18 +44,23 @@ void ResourceUsage::stop()
 {
     if (!m_start)
         return;
-    auto end = measure();
-    auto wall = std::chrono::duration_cast<std::chrono::microseconds>(end.wall - m_start.wall);
-    auto usr = end.user - m_start.user;
-    auto sys = end.system - m_start.system;
-    auto faults = end.page_faults - m_start.page_faults;
-    auto reclaims = end.page_reclaims - m_start.page_reclaims;
-    auto blk_in = end.blk_in - m_start.blk_in;
-    auto blk_out = end.blk_out - m_start.blk_out;
-    fmt::print("⧗ {:20} {:>8} µs real {:>8} µs usr {:>8} µs sys {:>5}"
-               " pg rclm {:>5} pg flt {:>5} blk in {:>5} blk out\n",
-               m_name, wall.count(), usr, sys,
-               reclaims, faults, blk_in, blk_out);
+    auto m = measure();
+    m.real_time -= m_start.real_time;
+    m.user_time -= m_start.user_time;
+    m.system_time -= m_start.system_time;
+    m.page_faults -= m_start.page_faults;
+#ifndef _WIN32
+    m.page_reclaims -= m_start.page_reclaims;
+    m.blk_in -= m_start.blk_in;
+    m.blk_out -= m_start.blk_out;
+    fmt::print("⧗ {:20} {:>8} µs real {:>8} µs usr {:>8} µs sys"
+               " {:>5} pg flt {:>5} pg rclm {:>5} blk in {:>5} blk out\n",
+               m_name, m.real_time, m.user_time, m.system_time,
+               m.page_faults, m.page_reclaims, m.blk_in, m.blk_out);
+#else
+    fmt::print("⧗ {:20} {:>8} µs real {:>8} µs usr {:>8} µs sys {:>5} pg flt\n",
+               m_name, m.real_time, m.user_time, m.system_time, m.page_faults);
+#endif
     m_start.reset();
 }
 
@@ -51,16 +68,31 @@ void ResourceUsage::stop()
 ResourceUsage::Measurements ResourceUsage::measure() const
 {
     ResourceUsage::Measurements res {};
-    res.wall = WallClock::now();
+    using namespace std::chrono;
+    res.real_time = duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count();
 #ifndef _WIN32
     struct rusage r_usage;
     if (getrusage(RUSAGE_SELF, &r_usage) == 0) {
-        res.user = timeval_to_micros(r_usage.ru_utime);
-        res.system = timeval_to_micros(r_usage.ru_stime);
+        res.user_time = timeval_to_micros(r_usage.ru_utime);
+        res.system_time = timeval_to_micros(r_usage.ru_stime);
         res.page_faults = r_usage.ru_majflt;
         res.page_reclaims = r_usage.ru_minflt;
         res.blk_in = r_usage.ru_inblock;
         res.blk_out = r_usage.ru_oublock;
+    }
+#else
+    FILETIME creation_time, exit_time, kernel_time, user_time;
+    if (GetProcessTimes(GetCurrentProcess(), &creation_time, &exit_time,
+                         &kernel_time, &user_time))
+    {
+        res.user_time = filetime_to_micros(user_time);
+        res.system_time = filetime_to_micros(kernel_time);
+    }
+
+    PROCESS_MEMORY_COUNTERS pmc;
+    if (GetProcessMemoryInfo(GetCurrentProcess(), &pmc, sizeof(pmc)))
+    {
+        res.page_faults = pmc.PageFaultCount;
     }
 #endif
     return res;

--- a/src/xci/core/ResourceUsage.cpp
+++ b/src/xci/core/ResourceUsage.cpp
@@ -1,0 +1,70 @@
+// ResourceUsage.cpp created on 2022-08-06 as part of xcikit project
+// https://github.com/rbrich/xcikit
+//
+// Copyright 2022 Radek Brich
+// Licensed under the Apache License, Version 2.0 (see LICENSE file)
+
+#include "ResourceUsage.h"
+#include <fmt/core.h>
+
+#ifndef _WIN32
+#include <sys/resource.h>
+#endif
+
+namespace xci::core {
+
+
+static uint64_t timeval_to_micros(const timeval& tv)
+{
+    return tv.tv_sec * 1'000'000 + tv.tv_usec;
+}
+
+
+void ResourceUsage::start(const char* name)
+{
+    if (name)
+        m_name = name;
+    m_start = measure();
+}
+
+
+void ResourceUsage::stop()
+{
+    if (!m_start)
+        return;
+    auto end = measure();
+    auto wall = std::chrono::duration_cast<std::chrono::microseconds>(end.wall - m_start.wall);
+    auto usr = end.user - m_start.user;
+    auto sys = end.system - m_start.system;
+    auto faults = end.page_faults - m_start.page_faults;
+    auto reclaims = end.page_reclaims - m_start.page_reclaims;
+    auto blk_in = end.blk_in - m_start.blk_in;
+    auto blk_out = end.blk_out - m_start.blk_out;
+    fmt::print("⧗ {:20} {:>8} µs real {:>8} µs usr {:>8} µs sys {:>5}"
+               " pg rclm {:>5} pg flt {:>5} blk in {:>5} blk out\n",
+               m_name, wall.count(), usr, sys,
+               reclaims, faults, blk_in, blk_out);
+    m_start.reset();
+}
+
+
+ResourceUsage::Measurements ResourceUsage::measure() const
+{
+    ResourceUsage::Measurements res {};
+    res.wall = WallClock::now();
+#ifndef _WIN32
+    struct rusage r_usage;
+    if (getrusage(RUSAGE_SELF, &r_usage) == 0) {
+        res.user = timeval_to_micros(r_usage.ru_utime);
+        res.system = timeval_to_micros(r_usage.ru_stime);
+        res.page_faults = r_usage.ru_majflt;
+        res.page_reclaims = r_usage.ru_minflt;
+        res.blk_in = r_usage.ru_inblock;
+        res.blk_out = r_usage.ru_oublock;
+    }
+#endif
+    return res;
+}
+
+
+} // namespace xci::core

--- a/src/xci/core/ResourceUsage.h
+++ b/src/xci/core/ResourceUsage.h
@@ -7,16 +7,13 @@
 #ifndef XCI_CORE_RESOURCEUSAGE_H
 #define XCI_CORE_RESOURCEUSAGE_H
 
-#include <chrono>
 #include <cstdint>
 
 namespace xci::core {
 
 /// Measure resource usage, including time.
-/// Uses getrusage(2) or similar.
-class ResourceUsage
-{
-    using WallClock = std::chrono::steady_clock;
+/// Uses getrusage(2) wherever available.
+class ResourceUsage {
 public:
     ResourceUsage() = default;
     explicit ResourceUsage(const char* name, bool start_now=true)
@@ -33,16 +30,18 @@ public:
 
 private:
     struct Measurements {
-        WallClock::time_point wall;
-        uint64_t user;
-        uint64_t system;
+        uint64_t real_time;  // microseconds
+        uint64_t user_time;  // microseconds
+        uint64_t system_time;  // microseconds
         long page_faults;
+#ifndef _WIN32
         long page_reclaims;
         long blk_in;
         long blk_out;
+#endif
 
-        void reset() { wall = WallClock::time_point{}; }
-        operator bool() const { return wall != WallClock::time_point{}; }
+        void reset() { real_time = 0; }
+        operator bool() const { return real_time != 0; }
     };
 
     Measurements measure() const;

--- a/src/xci/core/ResourceUsage.h
+++ b/src/xci/core/ResourceUsage.h
@@ -33,6 +33,7 @@ private:
         uint64_t real_time;  // microseconds
         uint64_t user_time;  // microseconds
         uint64_t system_time;  // microseconds
+        long max_rss;  // in kilobytes
         long page_faults;
 #ifndef _WIN32
         long page_reclaims;

--- a/src/xci/core/ResourceUsage.h
+++ b/src/xci/core/ResourceUsage.h
@@ -1,0 +1,56 @@
+// ResourceUsage.h created on 2022-08-06 as part of xcikit project
+// https://github.com/rbrich/xcikit
+//
+// Copyright 2022 Radek Brich
+// Licensed under the Apache License, Version 2.0 (see LICENSE file)
+
+#ifndef XCI_CORE_RESOURCEUSAGE_H
+#define XCI_CORE_RESOURCEUSAGE_H
+
+#include <chrono>
+#include <cstdint>
+
+namespace xci::core {
+
+/// Measure resource usage, including time.
+/// Uses getrusage(2) or similar.
+class ResourceUsage
+{
+    using WallClock = std::chrono::steady_clock;
+public:
+    ResourceUsage() = default;
+    explicit ResourceUsage(const char* name, bool start_now=true)
+            : m_name(name) {  if (start_now) start(); }
+    ~ResourceUsage() { stop(); }
+
+    void start(const char* name = nullptr);
+    void stop();
+
+    void start_if(bool condition, const char* name) {
+        if (condition)
+            start(name);
+    }
+
+private:
+    struct Measurements {
+        WallClock::time_point wall;
+        uint64_t user;
+        uint64_t system;
+        long page_faults;
+        long page_reclaims;
+        long blk_in;
+        long blk_out;
+
+        void reset() { wall = WallClock::time_point{}; }
+        operator bool() const { return wall != WallClock::time_point{}; }
+    };
+
+    Measurements measure() const;
+
+    const char* m_name = nullptr;
+    Measurements m_start;
+};
+
+} // namespace xci::core
+
+#endif  // include guard

--- a/src/xci/core/bit.h
+++ b/src/xci/core/bit.h
@@ -38,7 +38,7 @@ typename std::enable_if<
         std::is_trivially_copyable<From>::value &&
         std::is_trivial<To>::value &&
         !std::is_pointer<From>::value &&
-        sizeof(From) == 1,
+        (sizeof(From) == 1 || sizeof(From) == sizeof(To)),
         To>::type
 bit_copy(const From* src) noexcept
 {

--- a/tools/fire_script/Options.cpp
+++ b/tools/fire_script/Options.cpp
@@ -91,6 +91,7 @@ void Options::parse(char* argv[])
             Option("-M, --module-verbose", "Print compiled module content, including function bodies", ro.print_module_verbose),
             Option("-T, --module-ast", "Print compiled module content like -M, but dump generic functions as AST", ro.print_module_verbose_ast),
             Option("--trace", "Trace bytecode", ro.trace_bytecode),
+            Option("--rusage", "Measure time and resource utilization during compilation and execution", ro.print_rusage),
             Option("-p PASS_LIST", "Preprocess AST and stop, don't compile. "
                                    "PASS_LIST is comma separated list of pass names (or unique substrings of them): "
                                    + output_pass_list()

--- a/tools/fire_script/Options.h
+++ b/tools/fire_script/Options.h
@@ -14,6 +14,7 @@
 namespace xci::script::tool {
 
 struct ReplOptions {
+    bool print_rusage = false;
     bool print_raw_ast = false;
     bool print_ast = false;
     bool print_symtab = false;


### PR DESCRIPTION
Measure time and resource utilization.

For example, measure compiling std.fire:

```
> fire --rusage --no-std share/script/std.fire
⧗ parsed                   1922 µs real     1705 µs usr      173 µs sys     436 kB rss     0 pg flt   109 pg rclm     0 blk in     0 blk out
⧗ builtin imported            3 µs real        1 µs usr        1 µs sys       0 kB rss     0 pg flt     0 pg rclm     0 blk in     0 blk out
⧗ compiled                 1930 µs real     1554 µs usr      351 µs sys    1036 kB rss     0 pg flt   259 pg rclm     0 blk in     0 blk out
⧗ executed                    7 µs real        4 µs usr        3 µs sys      12 kB rss     0 pg flt     3 pg rclm     0 blk in     0 blk out
```