### PR TITLE
[text] Markup: color tags

### DIFF
--- a/examples/graphics/demo_fps.cpp
+++ b/examples/graphics/demo_fps.cpp
@@ -31,7 +31,7 @@ int main(int argc, const char* argv[])
     Theme theme(renderer);
     if (!theme.load_default())
         return EXIT_FAILURE;
-    auto& font = theme.font();
+    auto& font = theme.base_font();
 
     Shape rts(renderer, Color(0, 0, 40, 128), Color(180, 180, 0));
     rts.set_antialiasing(2);

--- a/examples/text/demo_font.cpp
+++ b/examples/text/demo_font.cpp
@@ -1,7 +1,7 @@
 // demo_font.cpp created on 2018-03-02 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2022 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "graphics/common.h"
@@ -65,14 +65,14 @@ int main(int argc, const char* argv[])
     text.set_color(Color::White());
 
     Text emoji;
-    emoji.set_markup_string("🥛🍸🥃🥂🍷🍹⚗️🧂");
+    emoji.set_fixed_string("🥛🍸🥃🥂🍷🍹⚗️🧂");
     emoji.set_font(emoji_font);
     emoji.set_font_size(10_vp);
 
     static constexpr auto help_color_normal = Color(200, 100, 50);
     static constexpr auto help_color_highlight = Color(255, 170, 120);
-    Text help_text(font, "<smooth><b>[s]</b> smooth scaling</smooth> <tab>"
-                         "<font><b>[f]</b> font scaling</font><br>"
+    Text help_text(font, "<s:smooth><b>[s]</b> smooth scaling</s:smooth> <tab>"
+                         "<s:font><b>[f]</b> font scaling</s:font><br>"
                          "(Resize window to observe the scaling effect.)", Text::Format::Markup);
     help_text.set_color(help_color_normal);
     help_text.set_font_size(5_vp);

--- a/examples/text/demo_layout.cpp
+++ b/examples/text/demo_layout.cpp
@@ -1,7 +1,7 @@
 // demo_layout.cpp created on 2018-03-10 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2022 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "graphics/common.h"
@@ -23,15 +23,15 @@ using namespace xci::core;
 // FIXME: comma may land on next line when reflowed
 
 static const char * sample_text =
-        "Each paragraph is broken into lines. "
-        "The lines are further <span1>broken into words</span1>, each of which "
-        "is shaped and rendered as a run of glyphs."
+        "Each paragraph is broken into <c:#AAF>lines</c>. "
+        "The lines are further <s:span1>broken into <c:#AAF>words</c></s:span1>, each of which "
+        "is shaped and rendered as a run of <c:#AAF>glyphs</c>."
         "\n\n"
         "Each line is bound to a base line, each word is attached to a base point. "
         "To justify the text to a column, the residual space can be uniformly "
-        "<span2>divided between all words</span2> on the line. (This is not yet implemented.)"
+        "<s:span2>divided between all words</s:span2> on the line. (This is not yet implemented.)"
         "\n\n"
-        "Here is a ligature: infinity ∞";
+        "Here is a ligature: in<c:#FAA>fi</c>nity ∞";
 
 
 int main(int argc, const char* argv[])

--- a/examples/text/demo_layout.cpp
+++ b/examples/text/demo_layout.cpp
@@ -81,9 +81,9 @@ int main(int argc, const char* argv[])
     help_text_2.set_color(Color(50, 200, 100));
     help_text_2.set_font_size(3_vp);
 
-    Text help_text_3(font, "Resize the window to watch the reflow.");
+    Text help_text_3(mono_font, "Resize the window to watch the reflow.");
     help_text_3.set_color(Color(200, 100, 50));
-    help_text_3.set_font_size(3.5_vp);
+    help_text_3.set_font_size(3_vp);
 
     Sprites font_texture(renderer, font.texture(), Color(0, 50, 255));
 

--- a/examples/text/demo_outline.cpp
+++ b/examples/text/demo_outline.cpp
@@ -1,7 +1,7 @@
 // demo_outline.cpp created on 2021-11-21 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2021–2022 Radek Brich
+// Copyright 2021–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "graphics/common.h"
@@ -20,10 +20,10 @@ using namespace xci::core;
 
 static const char * sample_text =
 "Text without outline. <i>Text without outline</i>\n\n"
-"<white_outline>Transparent text with white outline. <i>Transparent text with white outline.</i></white_outline>\n\n"
-"<black_white>Black text with white outline. <i>Black text with white outline.</i></black_white>\n\n"
-"<blue_white>Blue text with white outline. <i>Blue text with white outline.</i></blue_white>\n\n"
-"<white_red>White text with red outline. <i>White text with red outline.</i></white_red>\n\n"
+"<s:white_outline>Transparent text with white outline. <i>Transparent text with white outline.</i></s:white_outline>\n\n"
+"<s:black_white>Black text with white outline. <i>Black text with white outline.</i></s:black_white>\n\n"
+"<s:blue_white>Blue text with white outline. <i>Blue text with white outline.</i></s:blue_white>\n\n"
+"<s:white_red>White text with red outline. <i>White text with red outline.</i></s:white_red>\n\n"
 "";
 
 

--- a/examples/widgets/MousePosInfo.h
+++ b/examples/widgets/MousePosInfo.h
@@ -24,7 +24,7 @@ class MousePosInfo: public Widget {
 public:
     explicit MousePosInfo(Theme& theme)
             : Widget(theme),
-              m_text(theme.font(), "Mouse: ")
+              m_text(theme.base_font(), "Mouse: ")
     {
         m_text.set_color(Color(255, 150, 50));
     }

--- a/src/xci/core/log.h
+++ b/src/xci/core/log.h
@@ -1,7 +1,7 @@
 // log.h created on 2018-03-01 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_CORE_LOG_H
@@ -26,6 +26,7 @@ public:
         Info,
         Warning,
         Error,
+        None,  // disable logging
     };
 
     // Initialize default logger, Call this before anything that logs

--- a/src/xci/core/log_emscripten.cpp
+++ b/src/xci/core/log_emscripten.cpp
@@ -30,6 +30,8 @@ void Logger::default_handler(Logger::Level lvl, std::string_view msg)
         case Logger::Level::Error:
             em_level = EM_LOG_ERROR;
             break;
+        case Logger::Level::None:
+            return;
     }
     emscripten_log(EM_LOG_CONSOLE | em_level, "%s", std::string(msg).c_str());
 }

--- a/src/xci/core/string.cpp
+++ b/src/xci/core/string.cpp
@@ -1,7 +1,7 @@
 // string.cpp created on 2018-03-23 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "string.h"
@@ -186,6 +186,13 @@ std::string to_lower(std::string_view str)
         str.begin(), str.end(),
         result.begin(), [](char c){ return (char) std::tolower(c); });
     return result;
+}
+
+
+bool ci_equal(std::string_view s1, std::string_view s2)
+{
+    return std::equal(s1.begin(), s1.end(), s2.begin(), s2.end(),
+                      [](char a, char b) { return std::tolower(a) == std::tolower(b); });
 }
 
 

--- a/src/xci/core/string.h
+++ b/src/xci/core/string.h
@@ -1,7 +1,7 @@
 // string.h created on 2018-03-23 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_CORE_STRING_H
@@ -130,7 +130,10 @@ std::string unescape_uni(std::string_view str);
 // Convert string to lower case
 std::string to_lower(std::string_view str);
 
-// Convert UTF8 string to UTF32, ie. extract Unicode code points.
+// Case-insensitive string comparison
+bool ci_equal(std::string_view s1, std::string_view s2);
+
+// Convert UTF8 string to UTF32, i.e. extract Unicode code points.
 // In case of invalid source string, logs error and returns empty string.
 std::u32string to_utf32(std::string_view utf8);
 

--- a/src/xci/graphics/Color.cpp
+++ b/src/xci/graphics/Color.cpp
@@ -1,12 +1,19 @@
 // Color.cpp created on 2018-08-04 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Color.h"
+#include <xci/core/log.h>
+#include <xci/core/string.h>
+#include <array>
+#include <string_view>
+#include <sstream>
 
 namespace xci::graphics {
+
+using namespace xci::core;
 
 
 // Basic palette of 4-bit colors
@@ -27,6 +34,25 @@ static constexpr Color c_colors_4bit[16] = {
         {255,84,255},   // 13 - bright magenta
         {84,255,255},   // 14 - bright cyan
         {255,255,255},  // 15 - bright white
+};
+
+
+struct NamedColor{
+    constexpr NamedColor(std::string_view name, Color color) : name(name), color(color) {}
+    std::string_view name;
+    Color color;
+};
+
+
+static constexpr std::array c_named_colors = {
+    NamedColor("Black", Color::Black()),
+    NamedColor("White", Color::White()),
+    NamedColor("Red", Color::Red()),
+    NamedColor("Green", Color::Green()),
+    NamedColor("Blue", Color::Blue()),
+    NamedColor("Cyan", Color::Cyan()),
+    NamedColor("Magenta", Color::Magenta()),
+    NamedColor("Yellow", Color::Yellow()),
 };
 
 
@@ -56,6 +82,56 @@ Color::Color(uint8_t index) noexcept
     // 24 step grayscale
     index -= 232;
     r = g = b = uint8_t(8 + 10 * index);
+}
+
+
+Color::Color(std::string_view spec)
+{
+    if (spec.starts_with('#')) {
+        // parse hex digits
+        spec = spec.substr(1);
+        const auto len = spec.size();
+        uint32_t val;
+        std::istringstream(std::string(spec)) >> std::hex >> val;
+        if (len == 1 || len == 2) {
+            *this = Color(uint8_t(val));
+            return;
+        }
+        if (len == 3 || len == 4) {
+            if (len == 3)
+                val = (val << 4) | 0xF;
+            r = (val & 0xF000) >> 12;
+            g = (val & 0x0F00) >> 8;
+            b = (val & 0x00F0) >> 4;
+            a = (val & 0x000F);
+            r = (r << 4) | r;
+            g = (g << 4) | g;
+            b = (b << 4) | b;
+            a = (a << 4) | a;
+            return;
+        }
+        if (len == 6 || len == 8) {
+            if (len == 6)
+                val = (val << 8) | 0xFF;
+            r = (val & 0xFF000000) >> 24;
+            g = (val & 0x00FF0000) >> 16;
+            b = (val & 0x0000FF00) >> 8;
+            a = (val & 0x000000FF);
+            return;
+        }
+    } else {
+        // named colors
+        for (const auto& nc : c_named_colors) {
+            if (ci_equal(nc.name, spec)) {
+                *this = nc.color;
+                return;
+            }
+        }
+    }
+
+    // not matched
+    log::error("Color: could not interpret \"{}\"", spec);
+    *this = Color::Red();
 }
 
 

--- a/src/xci/graphics/Color.h
+++ b/src/xci/graphics/Color.h
@@ -1,7 +1,7 @@
 // Color.h created on 2018-03-04 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_GRAPHICS_COLOR_H
@@ -9,6 +9,8 @@
 
 #include <cstdint>
 #include <tuple>
+#include <string_view>
+#include <ostream>
 
 namespace xci::graphics {
 
@@ -50,7 +52,23 @@ struct Color {
     static constexpr Color Red() { return {255, 0, 0}; }
     static constexpr Color Green() { return {0, 255, 0}; }
     static constexpr Color Blue() { return {0, 0, 255}; }
+    static constexpr Color Cyan() { return {0, 255, 255}; }
+    static constexpr Color Magenta() { return {255, 0, 255}; }
     static constexpr Color Yellow() { return {255, 255, 0}; }
+
+    /// Parse color from string spec
+    ///
+    /// Supported formats:
+    /// * named color, e.g. "Black" (case insensitive)
+    /// * palette index / 1-2 hex digits, e.g. #07
+    /// * RGB / 3 hex digits, e.g. `#08f`
+    /// * RGBA / 4 hex digits, e.g. `#08f7`
+    /// * RGB / 6 hex digits, e.g. `#0080ff`
+    /// * RGBA / 8 hex digits, e.g. `#0080ff77`
+    ///
+    /// When the spec doesn't match any of these formats or any of known color names,
+    /// an error message is logged and the color is set to Red.
+    explicit Color(std::string_view spec);
 
     // Access components as float values (0.0 .. 1.0)
     // See FloatColor below for conversion of whole Color to float[4] format
@@ -67,6 +85,10 @@ struct Color {
     constexpr bool operator==(Color rhs) const
         { return std::tie(r, g, b, a) == std::tie(rhs.r, rhs.g, rhs.b, rhs.a); }
     constexpr bool operator!=(Color rhs) const { return !(rhs == *this); }
+
+    friend std::ostream& operator <<(std::ostream& s, Color c) {
+        return s << "Color(" << int(c.r) << ',' << int(c.g) << ',' << int(c.b) << ',' << int(c.a) << ')';
+    }
 
     // Direct access to components
     uint8_t r = 0;    // red

--- a/src/xci/text/Markup.cpp
+++ b/src/xci/text/Markup.cpp
@@ -1,7 +1,7 @@
 // Markup.cpp created on 2018-03-10 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Markup.h"
@@ -23,7 +23,10 @@ using namespace tao::pegtl;
 // ----------------------------------------------------------------------------
 // Grammar
 
-struct ControlSeq: seq< one<'<'>, plus<not_one<'<', '>'>>, one<'>'> > {};
+struct OpenElem: plus<not_one<'<', '>'>> {};
+struct CloseElem: plus<not_one<'<', '>'>> {};
+
+struct Tag: seq< one<'<'>, sor<seq<one<'/'>, CloseElem>, OpenElem>, one<'>'> > {};
 
 struct Word: plus<not_at<space>, sor< not_one<'<'>, two<'<'> >> {};
 
@@ -33,7 +36,7 @@ struct Tab: one<'\t'> {};
 
 struct Space: plus<space> {};
 
-struct Grammar: must< star<sor< ControlSeq, Word, Paragraph, Tab, Space >>, eof > {};
+struct Grammar: must< star<sor< Tag, Word, Paragraph, Tab, Space >>, eof > {};
 
 // ----------------------------------------------------------------------------
 // Actions
@@ -50,34 +53,56 @@ template<typename Rule>
 struct Action : nothing<Rule> {};
 
 template<>
-struct Action<ControlSeq>
+struct Action<OpenElem>
 {
     template<typename Input>
     static void apply(const Input &in, Markup &ctx)
     {
         dump_token("csq", in);
         auto seq = in.string();
-        if (seq == "<tab>")
+        if (seq == "tab")
             return ctx.get_layout().add_tab();
-        if (seq == "<br>")
+        if (seq == "br")
             return ctx.get_layout().finish_line();
-        if (seq == "<p>")
+        if (seq == "p")
             return ctx.get_layout().advance_line(0.5f);
-        if (seq == "<b>")
+        if (seq == "b")
             return ctx.get_layout().set_bold();
-        if (seq == "</b>")
-            return ctx.get_layout().set_bold(false);
-        if (seq == "<i>")
+        if (seq == "i")
             return ctx.get_layout().set_italic();
-        if (seq == "</i>")
-            return ctx.get_layout().set_italic(false);
-        if (seq[1] == '/') {
-            auto name = seq.substr(2, seq.size() - 3);
-            ctx.get_layout().end_span(name);
-        } else {
-            auto name = seq.substr(1, seq.size() - 2);
-            ctx.get_layout().begin_span(name);
+        if (seq.starts_with("c:")) {
+            return ctx.get_layout().set_color(graphics::Color(seq.substr(2)));
         }
+        if (seq.starts_with("s:")) {
+            auto name = seq.substr(2);
+            return ctx.get_layout().begin_span(name);
+        }
+        // Unknown tag - leave uninterpreted
+        ctx.get_layout().add_word(std::string("<") + seq + ">");
+    }
+};
+
+template<>
+struct Action<CloseElem>
+{
+    template<typename Input>
+    static void apply(const Input &in, Markup &ctx)
+    {
+        dump_token("end", in);
+        auto seq = in.string();
+        if (seq == "b")
+            return ctx.get_layout().set_bold(false);
+        if (seq == "i")
+            return ctx.get_layout().set_italic(false);
+        if (seq == "c" || seq.starts_with("c:")) {
+            return ctx.get_layout().reset_color();
+        }
+        if (seq.starts_with("s:")) {
+            auto name = seq.substr(2);
+            return ctx.get_layout().end_span(name);
+        }
+        // Unknown tag - leave uninterpreted
+        ctx.get_layout().add_word(std::string("</") + seq + ">");
     }
 };
 

--- a/src/xci/text/Markup.h
+++ b/src/xci/text/Markup.h
@@ -1,7 +1,7 @@
 // Markup.h created on 2018-03-10 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2019 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_TEXT_MARKUP_H
@@ -11,15 +11,17 @@
 
 namespace xci::text {
 
-/// Minimal XML-like markup language.
+/// Minimal markup language. Any similarity to HTML is purely coincidental.
 ///
-/// Supported tokens:
+/// Supported tags:
 /// * `<br>` - line break ('\n')
 /// * `<p>` or `\n\n` - paragraph break - not a pair element!
 /// * `<tab>` or `\t` - tabulator
-/// * `<b>` ... `</b>` - bold
-/// * `<i>` ... `</i>` - italic
-/// * `<name>` ... `</name>` - named span
+/// * `<b>`, `</b>` - bold, not bold
+/// * `<i>`, `</i>` - italic, not italic
+/// * `<c:#ABC>` - set RGB color (3 hex digits)
+/// * `</c>` - reset color to default
+/// * `<s:name>` ... `</s:name>` - named span
 
 class Markup {
 public:

--- a/src/xci/widgets/Button.cpp
+++ b/src/xci/widgets/Button.cpp
@@ -20,7 +20,7 @@ Button::Button(Theme& theme, const std::string &string)
               Color(10, 20, 40), theme.color(ColorId::Default))
 {
     set_focusable(true);
-    m_layout.set_default_font(&theme.font());
+    m_layout.set_default_font(&theme.base_font());
     Markup markup(m_layout);
     markup.parse(string);
 }

--- a/src/xci/widgets/FpsDisplay.cpp
+++ b/src/xci/widgets/FpsDisplay.cpp
@@ -39,7 +39,7 @@ void FpsDisplay::resize(View& view)
     m_quad.clear();
     create_sprite(view);
 
-    m_text.set_font(theme().font());
+    m_text.set_font(theme().base_font());
     m_text.set_font_size(size().y / 2);
 }
 

--- a/src/xci/widgets/Icon.cpp
+++ b/src/xci/widgets/Icon.cpp
@@ -60,7 +60,7 @@ void Icon::resize(View& view)
         m_layout.add_word(to_utf8(theme().icon_codepoint(m_icon_id)));
         m_layout.end_span("icon");
         m_layout.reset_offset();
-        m_layout.set_font(&theme().font());
+        m_layout.set_font(&theme().base_font());
         m_layout.add_space();
         m_layout.add_word(m_text);
         m_needs_refresh = false;

--- a/src/xci/widgets/Label.cpp
+++ b/src/xci/widgets/Label.cpp
@@ -14,7 +14,7 @@ using graphics::FramebufferCoords;
 Label::Label(Theme& theme)
     : Widget(theme)
 {
-    m_text.set_font(theme.font());
+    m_text.set_font(theme.base_font());
 }
 
 

--- a/src/xci/widgets/TextInput.cpp
+++ b/src/xci/widgets/TextInput.cpp
@@ -22,7 +22,7 @@ TextInput::TextInput(Theme& theme, const std::string& string)
       m_cursor_shape(theme.renderer(), Color::Yellow(), Color::Transparent())
 {
     set_focusable(true);
-    m_layout.set_default_font(&theme.font());
+    m_layout.set_default_font(&theme.base_font());
 }
 
 

--- a/src/xci/widgets/TextInput.cpp
+++ b/src/xci/widgets/TextInput.cpp
@@ -1,7 +1,7 @@
 // TextInput.cpp created on 2018-06-02 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2022 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "TextInput.h"
@@ -88,7 +88,9 @@ void TextInput::update(View& view, State state)
 {
     view.finish_draw();
     m_layout.update(view);
-    if (last_hover() == LastHover::Inside) {
+    if (state.focused) {
+        m_bg_rect.set_outline_color(theme().color(ColorId::Focus));
+    } else if (last_hover() == LastHover::Inside) {
         m_bg_rect.set_outline_color(theme().color(ColorId::Hover));
     } else {
         m_bg_rect.set_outline_color(theme().color(ColorId::Default));

--- a/src/xci/widgets/TextTerminal.cpp
+++ b/src/xci/widgets/TextTerminal.cpp
@@ -606,7 +606,7 @@ void terminal::Caret::draw(View& view, VariCoords pos)
 
 TextTerminal::TextTerminal(Theme& theme)
         : Widget(theme),
-          m_sprites(theme.renderer(), theme.font().texture(), Color(7)),
+          m_sprites(theme.renderer(), theme.base_font().texture(), Color(7)),
           m_emoji_sprites(theme.renderer(), theme.emoji_font().texture(), Color(7)),
           m_boxes(theme.renderer(), Color(0)),
           m_caret(theme.renderer()),
@@ -816,7 +816,7 @@ void TextTerminal::cancel_scrollback()
 void TextTerminal::resize(View& view)
 {
     Widget::resize(view);
-    auto& font = theme().font();
+    auto& font = theme().base_font();
     m_font_size = view.to_fb(m_font_size_requested);
     font.set_size(m_font_size.as<unsigned>());
     m_cell_size = {font.max_advance(), font.height()};
@@ -836,7 +836,7 @@ void TextTerminal::update(View& view, State state)
 {
     view.finish_draw();
 
-    auto& font = theme().font();
+    auto& font = theme().base_font();
     font.set_size(m_font_size.as<unsigned>());
 
     auto& emoji_font = theme().emoji_font();

--- a/src/xci/widgets/Theme.cpp
+++ b/src/xci/widgets/Theme.cpp
@@ -15,23 +15,26 @@ namespace xci::widgets {
 
 Theme::Theme(graphics::Renderer& renderer)
         : m_renderer(renderer),
-          m_font(renderer), m_emoji_font(renderer, 1024u), m_icon_font(renderer)
+          m_fonts{text::Font(renderer),  // base
+                  text::Font(renderer, 1024u),  // emoji
+                  text::Font(renderer),  // icon
+                  text::Font(renderer)}  // alt
 {}
 
 
 bool Theme::load_default()
 {
-    core::Vfs& vfs = m_renderer.vfs();
+    const core::Vfs& vfs = m_renderer.vfs();
 
     // Base font
-    TRY(load_font_face(vfs, "fonts/RobotoMono/RobotoMono_wght.ttf", 0));
-    TRY(load_font_face(vfs, "fonts/RobotoMono/RobotoMono-Italic_wght.ttf", 0));
+    TRY(load_font_face(vfs, "fonts/RobotoMono/RobotoMono_wght.ttf", 0, FontId::Base));
+    TRY(load_font_face(vfs, "fonts/RobotoMono/RobotoMono-Italic_wght.ttf", 0, FontId::Base));
 
     // Emoji font
-    TRY(load_emoji_font_face(vfs, "fonts/Noto/NotoColorEmoji.ttf", 0));
+    TRY(load_font_face(vfs, "fonts/Noto/NotoColorEmoji.ttf", 0, FontId::Emoji));
 
     // Material Icons
-    TRY(load_icon_font_face(vfs, "fonts/MaterialIcons/MaterialIcons-Regular.woff", 0));
+    TRY(load_font_face(vfs, "fonts/MaterialIcons/MaterialIcons-Regular.woff", 0, FontId::Icon));
     set_icon_codepoint(IconId::None, L' ');
     set_icon_codepoint(IconId::CheckBoxUnchecked, L'\ue835');
     set_icon_codepoint(IconId::CheckBoxChecked, L'\ue834');
@@ -47,21 +50,9 @@ bool Theme::load_default()
 }
 
 
-bool Theme::load_font_face(const core::Vfs& vfs, const char* file_path, int face_index)
+bool Theme::load_font_face(const core::Vfs& vfs, const char* file_path, int face_index, FontId font_id)
 {
-    return m_font.add_face(vfs, file_path, face_index);
-}
-
-
-bool Theme::load_emoji_font_face(const core::Vfs& vfs, const char* file_path, int face_index)
-{
-    return m_emoji_font.add_face(vfs, file_path, face_index);
-}
-
-
-bool Theme::load_icon_font_face(const core::Vfs& vfs, const char* file_path, int face_index)
-{
-    return m_icon_font.add_face(vfs, file_path, face_index);
+    return m_fonts[size_t(font_id)].add_face(vfs, file_path, face_index);
 }
 
 

--- a/src/xci/widgets/Theme.cpp
+++ b/src/xci/widgets/Theme.cpp
@@ -1,7 +1,7 @@
 // Theme.cpp created on 2018-04-10 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Theme.h"

--- a/src/xci/widgets/Theme.h
+++ b/src/xci/widgets/Theme.h
@@ -16,6 +16,13 @@ namespace xci::graphics { class Renderer; }
 
 namespace xci::widgets {
 
+enum class FontId {
+    Base,       // base font
+    Emoji,      // emoji font (fallback)
+    Icon,       // icons
+    Alt,        // alternative font
+};
+
 enum class IconId {
     None,
     CheckBoxUnchecked,
@@ -51,17 +58,20 @@ public:
     // default theme
     bool load_default();
 
-    // base font
-    bool load_font_face(const core::Vfs& vfs, const char* file_path, int face_index);
-    text::Font& font() { return m_font; }
-
-    // emoji font (fallback)
-    bool load_emoji_font_face(const core::Vfs& vfs, const char* file_path, int face_index);
-    text::Font& emoji_font() { return m_emoji_font; }
+    /// Load font face from VFS
+    /// Multiple faces can be loaded into the same target FontID, e.g. Regular, Bold, Italic.
+    /// \param vfs          VFS where to look for the font file
+    /// \param file_path    path to font file inside the VFS
+    /// \param face_index   index of font face in the font file which should be loaded (0 = default / single face)
+    /// \param font_id      target FontID to which the face should be added
+    bool load_font_face(const core::Vfs& vfs, const char* file_path, int face_index, FontId font_id);
+    text::Font& font(FontId font_id) { return m_fonts[size_t(font_id)]; }
+    text::Font& base_font() { return font(FontId::Base); }
+    text::Font& emoji_font() { return font(FontId::Emoji); }
+    text::Font& icon_font() { return font(FontId::Icon); }
+    text::Font& alt_font() { return font(FontId::Alt); }
 
     // icons
-    bool load_icon_font_face(const core::Vfs& vfs, const char* file_path, int face_index);
-    text::Font& icon_font() { return m_icon_font; }
     void set_icon_codepoint(IconId icon_id, text::CodePoint codepoint);
     text::CodePoint icon_codepoint(IconId icon_id);
 
@@ -71,9 +81,7 @@ public:
 
 private:
     graphics::Renderer& m_renderer;
-    text::Font m_font;  // base font
-    text::Font m_emoji_font;  // emojis
-    text::Font m_icon_font;  // icons
+    std::array<text::Font, sizeof(FontId)> m_fonts;
     IconMap m_icon_map {};
     // colors
     ColorMap m_color_map;

--- a/src/xci/widgets/Theme.h
+++ b/src/xci/widgets/Theme.h
@@ -1,7 +1,7 @@
 // Theme.h created on 2018-04-10 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018–2021 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #ifndef XCI_WIDGETS_THEME_H

--- a/tests/test_graphics.cpp
+++ b/tests/test_graphics.cpp
@@ -1,14 +1,16 @@
 // test_graphics.cpp created on 2018-08-04 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018 Radek Brich
+// Copyright 2018–2023 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include <catch2/catch_test_macros.hpp>
 
 #include <xci/graphics/Color.h>
 #include <xci/graphics/View.h>
+#include <xci/core/log.h>
 
+using namespace xci::core;
 using namespace xci::graphics;
 using namespace xci::graphics::unit_literals;
 
@@ -32,6 +34,25 @@ TEST_CASE( "Indexed colors", "[Color]" )
     CHECK( Color(232) == Color(8, 8, 8) );
     CHECK( Color(254) == Color(228, 228, 228) );
     CHECK( Color(255) == Color(238, 238, 238) );
+}
+
+
+TEST_CASE( "Color from string", "[Color]" )
+{
+    CHECK( Color("black") == Color::Black() );
+    CHECK( Color("White") == Color::White() );
+    CHECK( Color("CYAN") == Color::Cyan() );
+    CHECK( Color("#08f") == Color(0, 0x88, 0xff) );
+    CHECK( Color("#08f7") == Color(0, 0x88, 0xff, 0x77) );
+    CHECK( Color("#1234AB") == Color(0x12, 0x34, 0xAB) );
+    CHECK( Color("#1234AB00") == Color(0x12, 0x34, 0xAB, 0) );
+
+    // Invalid values => red color + log error
+    Logger::default_instance(Logger::Level::None);
+    CHECK( Color("UNKNOWN") == Color::Red() );
+    CHECK( Color("#12345") == Color::Red() );
+    CHECK( Color("#1234567") == Color::Red() );
+    CHECK( Color("#123456789") == Color::Red() );
 }
 
 


### PR DESCRIPTION
Add explicit color tags, e.g. `<c:#F77>red text</c>`, or `<c:Red>red text</c>`
As there is no style sheet, setting colors via spans is cumbersome.

Also refactor fonts in Theme so all use one common `load_font_face()`. Add fourth font - `alt_font()`.