### PR TITLE
[tools] find_file: add -E, --exclude, match whole path

### DIFF
--- a/src/xci/core/FileTree.h
+++ b/src/xci/core/FileTree.h
@@ -163,19 +163,15 @@ public:
             return {m_path_storage, m_dir_len};
         }
 
+        /// Get name part of contained path
         std::string_view name() const {
             return {m_path_storage + m_dir_len, m_name_len};
         }
 
-        /// To be used together with name_len().
-        /// NOT null-terminated.
-        const char* name_data() const {
-            return m_path_storage + m_dir_len;
-        }
-
-        unsigned int name_len() const { return m_name_len; }
-        bool name_empty() const { return m_name_len == 0; }
-        unsigned int size() const { return m_dir_len + m_name_len; }
+        bool has_name() const { return m_name_len != 0; }
+        unsigned dir_len() const { return m_dir_len; }
+        unsigned name_len() const { return m_name_len; }
+        unsigned size() const { return m_dir_len + m_name_len; }
 
         bool has_parent() const { return bool(m_parent); }
         int parent_fd() const { return m_parent->fd(); }

--- a/tools/find_file/ff.cpp
+++ b/tools/find_file/ff.cpp
@@ -34,7 +34,7 @@ using namespace xci::core;
 using namespace xci::core::argparser;
 
 
-static constexpr auto c_version = "0.8";
+static constexpr auto c_version = "0.9";
 
 
 enum PatternId: unsigned {


### PR DESCRIPTION
The exclude patterns are regex and there is still not .ignore file support, so yo need to write them all in command line:

```bash
ff examples/demo -E /node_modules/ -E /build/
```
Searches for files that begin with "demo" and reside in directory that ends with "examples". (I.e. this has to be substring of the path and the match must contain at least part of file name.)
Skips matches in directories named "node_modules" or "build".