### PR TITLE
[script] Type dot call: `T.type_name`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -27,6 +27,7 @@ Checks: >
   -misc-unused-parameters,
   -misc-non-private-member-variables-in-classes,
   -misc-no-recursion,
+  -misc-use-anonymous-namespace,
   modernize-*,
   -modernize-avoid-c-arrays,
   -modernize-deprecated-headers,

--- a/docs/script/syntax.adoc
+++ b/docs/script/syntax.adoc
@@ -1052,7 +1052,9 @@ The functions are usually generic, instantiated with type arguments, and taking 
 type_name = fun<T> Void -> String { /* compiler intrinsics */ }
 // Used as:
 type_name<String>   // -> "String"
-String.type_name    // equivalent
+type_name<[Int]>   // -> "[Int32]]"
+String.type_name    // equivalent to type_name<String>
+[Int].type_name     // ParseError - this notation works only on named types
 ----
 
 The last line is a syntax sugar.

--- a/share/script/std.fire
+++ b/share/script/std.fire
@@ -115,6 +115,9 @@ instance Exp Int64 { exp = { __exp 0x99 } }
 instance Exp Float32 { exp = { __exp 0xCC } }
 instance Exp Float64 { exp = { __exp 0xDD } }
 
+// Add strings => concatenate
+instance Add String { add = fun a b { string_concat a b } }
+
 
 // Comparison operators
 

--- a/src/xci/script/Builtin.cpp
+++ b/src/xci/script/Builtin.cpp
@@ -237,6 +237,7 @@ void BuiltinModule::add_string_functions()
 
     add_native_function("string_equal", {ti_string(), ti_string()}, ti_bool(), string_equal);
     add_native_function("string_compare", {ti_string(), ti_string()}, ti_int32(), string_compare);
+    add_native_function("string_concat", [](std::string_view a, std::string_view b) -> std::string { return std::string(a) + std::string(b); });
 }
 
 
@@ -416,6 +417,10 @@ static void introspect_module(Stack& stack, void*, void*)
 static void introspect_type_name(Stack& stack, void*, void*)
 {
     auto type_id = stack.pull<value::Int32>().value();
+    if (type_id == -1) {
+        stack.push(value::String{"unknown"});
+        return;
+    }
     const Module& mod = stack.frame().function.module();
     std::ostringstream os;
     if (type_id < 32) {

--- a/src/xci/script/ast/AST.cpp
+++ b/src/xci/script/ast/AST.cpp
@@ -197,6 +197,7 @@ void Reference::copy_to(Reference& r) const
     r.module = module;
     r.index = index;
     r.ti = ti;
+    r.type_args_ti = type_args_ti;
 }
 
 

--- a/src/xci/script/ast/resolve_spec.cpp
+++ b/src/xci/script/ast/resolve_spec.cpp
@@ -168,7 +168,8 @@ public:
                     // try to resolve via known type args
                     auto var = v.ti.generic_var();
                     const auto& type_args = m_scope.type_args();
-                    auto resolved = type_args.get(var);
+                    TypeInfo resolved;
+                    get_type_arg(var, resolved, type_args);
                     if (resolved) {
                         v.ti = resolved;
                     } else {

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -1024,6 +1024,8 @@ TEST_CASE( "Type introspection", "[script][interpreter]")
     CHECK(interpret_std("X=(name:String, age:Int); X.type_name") == R"=("(name: String, age: Int32)")=");
     CHECK(interpret_std("X=Int; type_name<X>") == R"=("Int32")=");
     CHECK(interpret_std("type MyInt=Int; type_name<MyInt>") == R"=("MyInt")=");
+    // type_name works on type vars, dot-call on type can take normal args
+    CHECK(interpret_std(R"(f=fun<T> a:String { a + T.type_name }; Int.f "The type is ")") == R"=("The type is Int32")=");
 }
 
 

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -1017,8 +1017,11 @@ TEST_CASE( "Explicit type params", "[script][interpreter]")
 TEST_CASE( "Type introspection", "[script][interpreter]")
 {
     CHECK(interpret_std("type_name<Void>; type_name<String>; type_name<Int>") == R"=("()";"String";"Int32")=");
+    CHECK(interpret_std("Void.type_name; String.type_name; Int.type_name") == R"=("()";"String";"Int32")=");
     CHECK(interpret_std("type_name<(Float,String)>; type_name<[Int64]>") == R"=("(Float32, String)";"[Int64]")=");
+    CHECK_THROWS_AS(parse("[Int].type_name"), ParseError);  // works only on names, not type expressions
     CHECK(interpret_std("type_name<(name:String, age:Int)>") == R"=("(name: String, age: Int32)")=");
+    CHECK(interpret_std("X=(name:String, age:Int); X.type_name") == R"=("(name: String, age: Int32)")=");
     CHECK(interpret_std("X=Int; type_name<X>") == R"=("Int32")=");
     CHECK(interpret_std("type MyInt=Int; type_name<MyInt>") == R"=("MyInt")=");
 }


### PR DESCRIPTION
Syntax sugar for calling functions on types:
* `T.type_name` => `type_name<T>`
* `T.fun arg` => `fun<T> arg`
