### PR TITLE
[script] add init syntax

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           cc_ver: 13
           cxx: clang++
           libcxx: libc++
-          apt: libc++-13-dev libc++abi-13-dev
+          apt: libc++-13-dev libc++abi-13-dev libc++-14-dev- libc++1-14- libc++abi-14-dev- libc++abi1-14- libunwind-14- libunwind-14-dev-
           build_args: ""
 #        - os: ubuntu-22.04
 #          name: "Clang 14 / Release"

--- a/docs/script/syntax.adoc
+++ b/docs/script/syntax.adoc
@@ -920,7 +920,7 @@ w 7                 // -> 16
 
 === Casting
 
-Any expression can be casted to another type.
+Any expression can be cast to another type.
 The syntax is similar as in variable definition with explicit type.
 
 [source,fire]
@@ -955,6 +955,39 @@ instance Cast MyType Int {
 instance Cast Int MyType {
     cast = fun x:Int { /* convert Int to MyType }
 }
+----
+
+=== Initializers
+
+Type names can be called. This syntax is translated to call of an `init` function of `Init` class.
+The default `init` function calls the `cast` function, so it supports same operations as <<Casting>>:
+
+[source,fire]
+----
+Int64(42)
+a = 42; Byte(a)
+Int64(1 + 2)
+String ['a', 'b', 'c']   // -> "abc"
+----
+
+As with `cast`, the `init` function can be called explicitly:
+
+[source,fire]
+----
+a:Int64 = init 42
+(init 42):Int64
+----
+
+User-defined types can have custom initializers:
+
+[source,fire]
+----
+type MyType = (Int, String)
+instance Init Int MyType {
+    init = fun a { (a, "Foo"):MyType }
+}
+MyType(42)  // -> (42, "Foo")
+42:MyType  // Error, cast doesn't fall back to init
 ----
 
 === Coercion

--- a/docs/script/syntax.adoc
+++ b/docs/script/syntax.adoc
@@ -990,6 +990,18 @@ MyType(42)  // -> (42, "Foo")
 42:MyType  // Error, cast doesn't fall back to init
 ----
 
+The initializer can also be called with the dot syntax:
+
+[source,fire]
+----
+(42).Int64
+42 .Int64
+42.Int64  // Syntax error: could be float literal suffix
+a = 42; a.Byte
+['a', 'b', 'c'].String   // -> "abc"
+----
+
+
 === Coercion
 
 The values of the same kind can coerce to a bigger type.

--- a/share/script/std.fire
+++ b/share/script/std.fire
@@ -281,6 +281,7 @@ class Ord <T> (Eq T) { }
 */
 
 
+// cast value of type T to type R: `value : R`
 class Cast T R {
     cast : T -> R
 }
@@ -348,6 +349,16 @@ instance Cast String [Byte] { cast = cast_to_bytes }
 instance Cast [Char] String { cast = cast_to_string }
 instance Cast [Byte] String { cast = cast_to_string }
 instance Cast Int32 TypeIndex { cast = { __noop } }
+
+
+// initializer for type R, with value of type T: `R value` or `value .R`
+class Init T R {
+    init : T -> R
+}
+
+// fallback to cast
+instance<T, R> Init T R { init = fun a { a:R } }
+
 
 class Bounded T {
     min : Void -> T

--- a/src/xci/script/Parser.cpp
+++ b/src/xci/script/Parser.cpp
@@ -64,6 +64,7 @@ struct SemicolonOrNewline: sor<one<';'>, eol, LineComment> {};
 struct SC: star< SpaceOrComment > {};  // optional space or comments
 struct NSC: star< NlSpaceOrComment > {};  // optional newlines, space or comments
 struct RS: at<space> {};  // require space
+struct RSP: at< sor<space, one<'('>> > {};  // require space or paren
 
 // Aux templates
 template<class T> struct SepList: list_tail<T, seq<SC, SemicolonOrNewline, NSC> > {};  // list separated by either semicolon or newline
@@ -145,12 +146,12 @@ struct Type: sor< ParenthesizedType, ListType, TypeName > {};
 // * some rules are parametrized with S (space type), choose either SC or NSC (allow newline)
 // * in general, rules inside parentheses or brackets use NSC, rules outside use SC
 // * this allows leaving out semicolons but still support multiline expressions
-template<class S> struct CallRight: seq< RS, S, ExprArgSafe > {};
-template<class S> struct Call: seq< ExprCallable, RS, S, ExprArgSafe > {};
-template<class S> struct TypeDotCallRight: seq< Reference, opt<RS, S, ExprArgSafe> > {};
-template<class S> struct TypeDotCall: if_must< one<'.'>, SC, TypeDotCallRight<S> > {};
-template<class S> struct ExprTypeDotCall: seq< TypeName, TypeDotCall<S> > {};
-template<class S> struct ExprOperand: sor<Call<S>, ExprArgSafe, ExprPrefix, ExprTypeDotCall<S>> {};
+template<class S> struct CallRight: seq< RSP, S, ExprArgSafe > {};
+template<class S> struct Call: seq< ExprCallable, RSP, S, ExprArgSafe > {};
+template<class S> struct TypeDotCallRight: seq< Reference, opt<RSP, S, ExprArgSafe> > {};
+template<class S> struct ExprTypeDotCall: seq< TypeName, S, if_must< one<'.'>, SC, TypeDotCallRight<S> > > {};
+template<class S> struct ExprTypeInit: seq< TypeName, RSP, S, ExprArgSafe > {};
+template<class S> struct ExprOperand: sor<Call<S>, ExprArgSafe, ExprPrefix, ExprTypeInit<S>, ExprTypeDotCall<S>> {};
 template<class S> struct DotCallRight: seq< NSC, one<'.'>, SC, must<ExprOperand<S>> > {};
 template<class S> struct ExprInfixRight: seq< sor< CallRight<S>, DotCallRight<S>, seq<S, InfixOperator, NSC, ExprOperand<S>> >, opt< ExprInfixRight<S> > > {};
 template<class S> struct TrailingComma: opt<S, one<','>> {};
@@ -590,6 +591,12 @@ struct Action<ExprArgSafe> : change_states< std::unique_ptr<ast::Expression> > {
     }
 
     template<typename Input>
+    static void success(const Input &in, std::unique_ptr<ast::Expression>& expr, ast::Cast& cast) {
+        assert(!cast.expression);
+        cast.expression = std::move(expr);
+    }
+
+    template<typename Input>
     static void success(const Input &in, std::unique_ptr<ast::Expression>& expr, ast::WithContext& with) {
         assert(!with.context);
         with.context = std::move(expr);
@@ -658,6 +665,27 @@ struct Action<DotCallRight<S>> {
     template<typename Input>
     static void apply(const Input &in, ast::OpCall& opc) {
         opc.op = ast::Operator::DotCall;
+    }
+};
+
+
+template<class S>
+struct Action<ExprTypeInit<S>> : change_states< ast::Cast > {
+    template<typename Input>
+    static void apply(const Input &in, ast::Cast& init) {
+        init.source_loc.load(in.input(), in.position());
+        init.is_init = true;
+    }
+
+    template<typename Input>
+    static void success(const Input &in, ast::Cast& init, std::unique_ptr<ast::Expression>& expr) {
+        expr = std::make_unique<ast::Cast>(std::move(init));
+    }
+
+    template<typename Input>
+    static void success(const Input &in, ast::Cast& init, ast::OpCall& outer) {
+        assert(!outer.arg);
+        outer.arg = std::make_unique<ast::Cast>(std::move(init));
     }
 };
 
@@ -770,9 +798,15 @@ struct Action<TypeName> : change_states< ast::TypeName > {
     }
 
 
-    template<typename Input>
+    template<typename Input>                                   // Cast
     static void success(const Input &in, ast::TypeName& tname, RefCall& rcall) {
         rcall.type = std::make_unique<ast::TypeName>(std::move(tname));
+    }
+
+    template<typename Input>
+    static void success(const Input &in, ast::TypeName& tname, ast::Cast& cast) {
+        assert(!cast.type);
+        cast.type = std::make_unique<ast::TypeName>(std::move(tname));
     }
 
     template<typename Input>

--- a/src/xci/script/ast/AST.cpp
+++ b/src/xci/script/ast/AST.cpp
@@ -360,7 +360,8 @@ std::unique_ptr<ast::Expression> Cast::make_copy() const
         r->cast_function = std::make_unique<Reference>();
         cast_function->copy_to(*r->cast_function);
     }
-    r->to_type = to_type;
+    r->ti = ti;
+    r->is_init = is_init;
     return r;
 }
 

--- a/src/xci/script/ast/AST.h
+++ b/src/xci/script/ast/AST.h
@@ -558,14 +558,16 @@ struct Cast: public Expression {
     void apply(ConstVisitor& visitor) const override { visitor.visit(*this); }
     void apply(Visitor& visitor) override { visitor.visit(*this); }
     std::unique_ptr<ast::Expression> make_copy() const override;
-    const TypeInfo& type_info() const override { return to_type; }
+    const TypeInfo& type_info() const override { return ti; }
 
     std::unique_ptr<Expression> expression;
     std::unique_ptr<Type> type;
-    std::unique_ptr<Reference> cast_function;  // none for cast to Void or to same type
 
     // resolved:
-    TypeInfo to_type;    // resolved Type (cast to)
+    std::unique_ptr<Reference> cast_function;  // none for cast to Void or to same type
+    TypeInfo ti;    // resolved type (cast to)
+
+    bool is_init = false;  // Cast and Init share same AST node
 };
 
 

--- a/src/xci/script/ast/fold_dot_call.cpp
+++ b/src/xci/script/ast/fold_dot_call.cpp
@@ -59,6 +59,15 @@ public:
             // Collapse inner Call into outer OpCall (with op=DotCall)
             assert(!v.callable);
             assert(v.arg && v.right_arg);
+            // collapse Cast (dot type init, i.e. `1 .Int`)
+            auto* cast = dynamic_cast<ast::Cast*>(v.right_arg.get());
+            if (cast) {
+                m_collapsed = std::move(v.right_arg);
+                assert(cast->type);
+                assert(!cast->expression);
+                cast->expression = std::move(v.arg);
+                return;
+            }
             auto* call = dynamic_cast<ast::Call*>(v.right_arg.get());
             if (call) {
                 m_collapsed = std::move(v.right_arg);
@@ -134,7 +143,8 @@ public:
     void visit(ast::Reference&) override {}
 
     void visit(ast::Cast& v) override {
-        v.expression->apply(*this);
+        if (v.expression)
+            v.expression->apply(*this);
     }
 
     void visit(ast::Class&) override {}

--- a/src/xci/script/ast/fold_tuple.cpp
+++ b/src/xci/script/ast/fold_tuple.cpp
@@ -109,7 +109,8 @@ public:
     void visit(ast::Reference&) override {}
 
     void visit(ast::Cast& v) override {
-        apply_and_fold(v.expression);
+        if (v.expression)
+            apply_and_fold(v.expression);
     }
 
     void visit(ast::Class&) override {}

--- a/src/xci/script/ast/resolve_decl.cpp
+++ b/src/xci/script/ast/resolve_decl.cpp
@@ -352,7 +352,7 @@ public:
     void visit(ast::Cast& v) override {
         // resolve the target type -> m_type_info
         v.type->apply(*this);
-        v.to_type = std::move(m_type_info);
+        v.ti = std::move(m_type_info);
 
         v.expression->apply(*this);
     }

--- a/src/xci/script/ast/resolve_symbols.cpp
+++ b/src/xci/script/ast/resolve_symbols.cpp
@@ -330,7 +330,7 @@ public:
     void visit(ast::Cast& v) override {
         v.expression->apply(*this);
         v.type->apply(*this);
-        v.cast_function = std::make_unique<ast::Reference>(ast::Identifier{"cast"});
+        v.cast_function = std::make_unique<ast::Reference>(ast::Identifier{v.is_init ? "init" : "cast"});
         v.cast_function->source_loc = v.source_loc;
         v.cast_function->apply(*this);
     }

--- a/src/xci/script/ast/resolve_types.cpp
+++ b/src/xci/script/ast/resolve_types.cpp
@@ -536,24 +536,25 @@ public:
 
     // The cast expression is translated to a call to `cast` method from the Cast class.
     // The inner expression type and the cast type are used to look up the instance of Cast.
+    // (Or same for `init` method from Init class.)
     void visit(ast::Cast& v) override {
         // resolve the inner expression -> m_value_type
         // (the Expression might use the specified type from `m_cast_type`)
-        resolve_generic_type(v.to_type, m_scope);
-        m_cast_type = v.to_type;
+        resolve_generic_type(v.ti, m_scope);
+        m_cast_type = v.is_init ? TypeInfo{} : v.ti;
         m_call_sig.clear();
         v.expression->apply(*this);
         m_cast_type = {};
         m_value_type = m_value_type.effective_type();
         // Cast to the same type or same underlying type (from/to a named type) -> noop
-        if (is_same_underlying(m_value_type, v.to_type)) {
+        if (!v.is_init && is_same_underlying(m_value_type, v.ti)) {
             v.cast_function.reset();
-            m_value_type = v.to_type;
+            m_value_type = v.ti;
             return;
         }
         // lookup the cast function with the resolved arg/return types
         m_call_sig.emplace_back().set_arg({m_value_type, v.expression->source_loc});
-        m_call_sig.back().set_return_type(v.to_type);
+        m_call_sig.back().set_return_type(v.ti);
         v.cast_function->apply(*this);
         // set the effective type of the Cast expression and clean the call types
         m_value_type = std::move(m_call_sig.back().return_type);

--- a/src/xci/script/dump.cpp
+++ b/src/xci/script/dump.cpp
@@ -591,9 +591,9 @@ std::ostream& operator<<(std::ostream& os, const Function& v)
 std::ostream& operator<<(std::ostream& os, const Cast& v)
 {
     if (stream_options(os).enable_tree) {
-        os << "Cast(Expression)";
-        if (v.to_type)
-            os << " [type_info=" << v.to_type << ']';
+        os << (v.is_init ? "Init(Expression)" : "Cast(Expression)");
+        if (v.ti)
+            os << " [type_info=" << v.ti << ']';
         os << endl
            << more_indent
            << put_indent << *v.expression
@@ -602,7 +602,10 @@ std::ostream& operator<<(std::ostream& os, const Cast& v)
             os << put_indent << *v.cast_function;
         return os << less_indent;
     } else {
-        return os << *v.expression << ":" << *v.type;
+        if (v.is_init)
+            return os << *v.type << ' ' << *v.expression;
+        else
+            return os << *v.expression << ':' << *v.type;
     }
 }
 

--- a/src/xci/script/dump.cpp
+++ b/src/xci/script/dump.cpp
@@ -595,9 +595,10 @@ std::ostream& operator<<(std::ostream& os, const Cast& v)
         if (v.ti)
             os << " [type_info=" << v.ti << ']';
         os << endl
-           << more_indent
-           << put_indent << *v.expression
-           << put_indent << *v.type;
+           << more_indent;
+        if (v.expression)
+           os << put_indent << *v.expression;
+        os << put_indent << *v.type;
         if (v.cast_function)
             os << put_indent << *v.cast_function;
         return os << less_indent;

--- a/tests/test_script.cpp
+++ b/tests/test_script.cpp
@@ -969,6 +969,11 @@ TEST_CASE( "Initializer", "[script][interpreter]" )
                         "    init = fun a { (a, \"Foo\"):MyType }\n"
                         "}\n"
                         "MyType(42)") == "(42, \"Foo\")");
+    // dot type init
+    CHECK(interpret_std("(42).Int64") == "42L");
+    CHECK(interpret_std("42 .Int64") == "42L");
+    CHECK(interpret_std("a = 42; a.Byte") == "b'*'");
+    CHECK(interpret_std("['a', 'b', 'c'].String") == "\"abc\"");
 }
 
 


### PR DESCRIPTION
With fallback to cast, but not same - allow different user function than cast.

Syntax similar to function call, but with a type name. Doesn't work with composed types like `(Int, String)` or `[Int]`.
```
Int64 42
Int64 (42)
Int64(42)
```

User-defined type with init:
```
type MyType = (Int, String)
instance Init Int MyType {
    init = fun a { (a, "Foo"):MyType }
}
MyType(42)  // -> (42, "Foo")
```

Resolves #184
