### PR TITLE
[script] reduce bloat generated by std::visit in Value::binary_op()

### DIFF
--- a/extras/lldb_formatters/xci_script_lldb.py
+++ b/extras/lldb_formatters/xci_script_lldb.py
@@ -104,8 +104,7 @@ class TypeInfo_SyntheticChildrenProvider:
         self.active_member = None
 
     def update(self):
-        union = self.valobj.GetChildAtIndex(0)
-        self.m_type = union.GetChildMemberWithName("m_type")
+        self.m_type = self.valobj.GetChildMemberWithName("m_type")
         self.m_key = self.valobj.GetChildMemberWithName("m_key")
         self.m_is_literal = self.valobj.GetChildMemberWithName("m_is_literal")
         type_ = self.m_type.value
@@ -121,7 +120,7 @@ class TypeInfo_SyntheticChildrenProvider:
             active_member_name = None
             self.active_member = None
         if active_member_name is not None:
-            self.active_member = union.GetChildMemberWithName(active_member_name)
+            self.active_member = self.valobj.GetChildMemberWithName(active_member_name)
 
     def num_children(self):
         n = 3  # m_type, m_key, m_is_literal

--- a/src/xci/core/container/StaticVec.h
+++ b/src/xci/core/container/StaticVec.h
@@ -32,10 +32,10 @@ public:
     StaticVec(std::span<const T> r);
 
     StaticVec(const StaticVec& r);
-    StaticVec(StaticVec&& r) = default;
+    StaticVec(StaticVec&& r);
 
     StaticVec& operator=(const StaticVec& r);
-    StaticVec& operator=(StaticVec&& r) = default;
+    StaticVec& operator=(StaticVec&& r);
 
     friend bool operator==(const StaticVec& a, const StaticVec& b) {
         return a.size() == b.size() && std::equal(a.begin(), a.end(), b.begin());
@@ -99,12 +99,26 @@ StaticVec<T>::StaticVec(const StaticVec& r)
 }
 
 template<class T>
+StaticVec<T>::StaticVec(StaticVec&& r)
+        : m_vec(std::move(r.m_vec)), m_size(r.size())
+{
+    r.m_size = 0;
+}
+
+template<class T>
 auto StaticVec<T>::operator=(const StaticVec& r) -> StaticVec& {
     reset(r.size());
     std::copy(r.begin(), r.end(), m_vec.get());
     return *this;
 }
 
+template<class T>
+auto StaticVec<T>::operator=(StaticVec&& r) -> StaticVec& {
+    m_vec = std::move(r.m_vec);
+    m_size = r.m_size;
+    r.m_size = 0;
+    return *this;
+}
 
 template<class T>
 void StaticVec<T>::reset(size_t new_size) {

--- a/src/xci/script/Builtin.h
+++ b/src/xci/script/Builtin.h
@@ -43,147 +43,112 @@ constexpr T shift_right( T&& lhs, uint8_t rhs ) noexcept {
     return std::forward<T>(lhs) >> rhs;
 }
 
-// Similar to std::plus, but with a single type (especially the return type is not promoted)
-struct UnsafeAdd {
-    template<class T>
-    constexpr T operator()(const T& lhs, const T& rhs ) const { return lhs + rhs; }
-};
-
-struct UnsafeSub {
-    template<class T>
-    constexpr T operator()(const T& lhs, const T& rhs ) const { return lhs - rhs; }
-};
-
-struct UnsafeMul {
-    template<class T>
-    constexpr T operator()(const T& lhs, const T& rhs ) const { return lhs * rhs; }
-};
-
-struct UnsafeDiv {
-    template<class T>
-    constexpr T operator()(const T& lhs, const T& rhs ) const { return lhs / rhs; }
-};
-
-struct UnsafeMod {
-    template<class T>
-    constexpr T operator()(const T& lhs, const T& rhs ) const {
-        if constexpr (std::is_integral_v<T> || std::is_same_v<T, uint128> || std::is_same_v<T, int128>) {
-            return lhs % rhs;
-        } else if constexpr (std::is_same_v<T, float>) {
-            return fmodf(lhs, rhs);
-        } else if constexpr (std::is_same_v<T, double>) {
-            return fmod(lhs, rhs);
-        } else if constexpr (std::is_same_v<T, long double> || std::is_same_v<T, float128>) {
-            return fmodl(lhs, rhs);
-        }
-    }
-};
-
 // Safe add with overflow check
-struct Add {
-    template<class T>
-    constexpr T operator()(const T& lhs, const T& rhs ) const {
+template<class T>
+constexpr T add(const T& lhs, const T& rhs ) {
 #if defined(__GNUC__)
-        if constexpr (std::is_integral_v<T>) {
-            T r;
-            if (__builtin_add_overflow(lhs, rhs, &r))
-                throw value_out_of_range("Integer overflow");
-            return r;
-        } else
+    if constexpr (std::is_integral_v<T>) {
+        T r;
+        if (__builtin_add_overflow(lhs, rhs, &r))
+            throw value_out_of_range("Integer overflow");
+        return r;
+    } else
 #endif
-             return lhs + rhs;
-    }
-};
+        return lhs + rhs;
+}
 
-struct Sub {
-    template<class T>
-    constexpr T operator()(const T& lhs, const T& rhs ) const {
+template<class T>
+constexpr T sub(const T& lhs, const T& rhs ) {
 #if defined(__GNUC__)
-        if constexpr (std::is_integral_v<T>) {
-             T r;
-             if (__builtin_sub_overflow(lhs, rhs, &r))
-                throw value_out_of_range("Integer overflow");
-             return r;
-        } else
+    if constexpr (std::is_integral_v<T>) {
+         T r;
+         if (__builtin_sub_overflow(lhs, rhs, &r))
+            throw value_out_of_range("Integer overflow");
+         return r;
+    } else
 #endif
-             return lhs - rhs;
-    }
-};
+         return lhs - rhs;
+}
 
-struct Mul {
-    template<class T>
-    constexpr T operator()(const T& lhs, const T& rhs ) const {
+template<class T>
+constexpr T mul(const T& lhs, const T& rhs ) {
 #if defined(__GNUC__)
-        // Note: fails to link with int128 on Linux with Clang (undefined reference to `__muloti4')
-        if constexpr (std::is_integral_v<T> && sizeof(T) <= 8) {
-             T r;
-             if (__builtin_mul_overflow(lhs, rhs, &r))
-                throw value_out_of_range("Integer overflow");
-             return r;
-        } else
+    // Note: fails to link with int128 on Linux with Clang (undefined reference to `__muloti4')
+    if constexpr (std::is_integral_v<T> && sizeof(T) <= 8) {
+         T r;
+         if (__builtin_mul_overflow(lhs, rhs, &r))
+            throw value_out_of_range("Integer overflow");
+         return r;
+    } else
 #endif
-             return lhs * rhs;
-    }
-};
+         return lhs * rhs;
+}
 
-struct Div {
-    template<class T>
-    constexpr T operator()(const T& lhs, const T& rhs ) const {
-        if constexpr (std::is_integral_v<T>) {
-             if (rhs == 0)
-                throw value_out_of_range("Division by zero");
-             return lhs / rhs;
-        } else
-             return lhs / rhs;
-    }
-};
+template<class T>
+constexpr T div(const T& lhs, const T& rhs ) {
+    if constexpr (std::is_integral_v<T>) {
+         if (rhs == 0)
+            throw value_out_of_range("Division by zero");
+         return lhs / rhs;
+    } else
+         return lhs / rhs;
+}
 
-struct Mod {
-    template<class T>
-    constexpr T operator()(const T& lhs, const T& rhs ) const {
-        if constexpr (std::is_integral_v<T> || std::is_same_v<T, uint128> || std::is_same_v<T, int128>) {
-             if (rhs == 0)
-                throw value_out_of_range("Division by zero");
-             return lhs % rhs;
-        } else if constexpr (std::is_same_v<T, float>) {
-             return fmodf(lhs, rhs);
-        } else if constexpr (std::is_same_v<T, double>) {
-             return fmod(lhs, rhs);
-        } else if constexpr (std::is_same_v<T, long double> || std::is_same_v<T, float128>) {
-             return fmodl(lhs, rhs);
-        }
+template<class T>
+constexpr T mod(const T& lhs, const T& rhs ) {
+    if constexpr (std::is_integral_v<T> || std::is_same_v<T, uint128> || std::is_same_v<T, int128>) {
+         if (rhs == 0)
+            throw value_out_of_range("Division by zero");
+         return lhs % rhs;
+    } else if constexpr (std::is_same_v<T, float>) {
+         return fmodf(lhs, rhs);
+    } else if constexpr (std::is_same_v<T, double>) {
+         return fmod(lhs, rhs);
+    } else if constexpr (std::is_same_v<T, long double> || std::is_same_v<T, float128>) {
+         return fmodl(lhs, rhs);
     }
-};
+}
 
-struct Exp {
-    template<class T>
-    constexpr T operator()(T x, T n ) const noexcept
-    {
-        if constexpr (std::is_integral_v<T> || std::is_same_v<T, uint128> || std::is_same_v<T, int128>) {
-             // https://en.wikipedia.org/wiki/Exponentiation_by_squaring
-             if (n == 0)
-                return 1;
-             if (n < 0) {
-                x = 1 / x;
-                n = -n;
-             }
-             T res = 1;
-             while (n > 1) {
-                if (n & 1)
-                    res *= x;
-                x *= x;
-                n >>= 1;
-             }
-             return res * x;
-        } else if constexpr (std::is_same_v<T, float>) {
-             return powf(x, n);
-        } else if constexpr (std::is_same_v<T, double>) {
-             return pow(x, n);
-        } else if constexpr (std::is_same_v<T, long double> || std::is_same_v<T, float128>) {
-             return powl(x, n);
-        }
+template<class T>
+constexpr T unsafe_mod(const T& lhs, const T& rhs ) noexcept {
+    if constexpr (std::is_integral_v<T> || std::is_same_v<T, uint128> || std::is_same_v<T, int128>) {
+        return lhs % rhs;
+    } else if constexpr (std::is_same_v<T, float>) {
+        return fmodf(lhs, rhs);
+    } else if constexpr (std::is_same_v<T, double>) {
+        return fmod(lhs, rhs);
+    } else if constexpr (std::is_same_v<T, long double> || std::is_same_v<T, float128>) {
+        return fmodl(lhs, rhs);
     }
-};
+}
+
+template<class T>
+constexpr T exp(T x, T n ) noexcept
+{
+    if constexpr (std::is_integral_v<T> || std::is_same_v<T, uint128> || std::is_same_v<T, int128>) {
+         // https://en.wikipedia.org/wiki/Exponentiation_by_squaring
+         if (n == 0)
+            return 1;
+         if (n < 0) {
+            x = 1 / x;
+            n = -n;
+         }
+         T res = 1;
+         while (n > 1) {
+            if (n & 1)
+                res *= x;
+            x *= x;
+            n >>= 1;
+         }
+         return res * x;
+    } else if constexpr (std::is_same_v<T, float>) {
+         return powf(x, n);
+    } else if constexpr (std::is_same_v<T, double>) {
+         return pow(x, n);
+    } else if constexpr (std::is_same_v<T, long double> || std::is_same_v<T, float128>) {
+         return powl(x, n);
+    }
+}
 
 const char* op_to_function_name(ast::Operator::Op op);
 

--- a/src/xci/script/Machine.cpp
+++ b/src/xci/script/Machine.cpp
@@ -116,12 +116,12 @@ void Machine::run(const InvokeCallback& cb)
 
             case Opcode::LogicalOr:
             case Opcode::LogicalAnd: {
-                auto lhs = m_stack.pull<value::Bool>();
-                auto rhs = m_stack.pull<value::Bool>();
+                const auto lhs = m_stack.pull<value::Bool>();
+                const auto rhs = m_stack.pull<value::Bool>();
                 switch (opcode) {
-                    case Opcode::LogicalOr:   m_stack.push(lhs.binary_op<std::logical_or<>, true>(rhs)); break;
-                    case Opcode::LogicalAnd:  m_stack.push(lhs.binary_op<std::logical_and<>, true>(rhs)); break;
-                    default: break;
+                    case Opcode::LogicalOr:   m_stack.push(Value(lhs.value() || lhs.value())); break;
+                    case Opcode::LogicalAnd:  m_stack.push(Value(lhs.value() && rhs.value())); break;
+                    default: XCI_UNREACHABLE;
                 }
                 break;
             }
@@ -152,94 +152,69 @@ void Machine::run(const InvokeCallback& cb)
                 break;
             }
 
-            case Opcode::BitwiseOr_8: {
-                auto lhs = m_stack.pull<value::UInt8>();
-                auto rhs = m_stack.pull<value::UInt8>();
-                m_stack.push(lhs.binary_op<std::bit_or<>, true>(rhs));
-                break;
-            }
-            case Opcode::BitwiseAnd_8: {
-                auto lhs = m_stack.pull<value::UInt8>();
-                auto rhs = m_stack.pull<value::UInt8>();
-                m_stack.push(lhs.binary_op<std::bit_and<>, true>(rhs));
-                break;
-            }
+            case Opcode::BitwiseOr_8:
+            case Opcode::BitwiseAnd_8:
             case Opcode::BitwiseXor_8: {
-                auto lhs = m_stack.pull<value::UInt8>();
-                auto rhs = m_stack.pull<value::UInt8>();
-                m_stack.push(lhs.binary_op<std::bit_xor<>, true>(rhs));
+                const auto lhs = m_stack.pull<value::UInt8>();
+                const auto rhs = m_stack.pull<value::UInt8>();
+                switch (opcode) {
+                    case Opcode::BitwiseOr_8:   m_stack.push(Value(lhs.value() | rhs.value())); break;
+                    case Opcode::BitwiseAnd_8:  m_stack.push(Value(lhs.value() & rhs.value())); break;
+                    case Opcode::BitwiseXor_8:  m_stack.push(Value(lhs.value() ^ rhs.value())); break;
+                    default: XCI_UNREACHABLE;
+                }
                 break;
             }
-            case Opcode::BitwiseOr_16: {
-                auto lhs = m_stack.pull<value::UInt16>();
-                auto rhs = m_stack.pull<value::UInt16>();
-                m_stack.push(lhs.binary_op<std::bit_or<>, true>(rhs));
-                break;
-            }
-            case Opcode::BitwiseAnd_16: {
-                auto lhs = m_stack.pull<value::UInt16>();
-                auto rhs = m_stack.pull<value::UInt16>();
-                m_stack.push(lhs.binary_op<std::bit_and<>, true>(rhs));
-                break;
-            }
+            case Opcode::BitwiseOr_16:
+            case Opcode::BitwiseAnd_16:
             case Opcode::BitwiseXor_16: {
-                auto lhs = m_stack.pull<value::UInt16>();
-                auto rhs = m_stack.pull<value::UInt16>();
-                m_stack.push(lhs.binary_op<std::bit_xor<>, true>(rhs));
+                const auto lhs = m_stack.pull<value::UInt16>();
+                const auto rhs = m_stack.pull<value::UInt16>();
+                switch (opcode) {
+                    case Opcode::BitwiseOr_16:  m_stack.push(Value(lhs.value() | rhs.value())); break;
+                    case Opcode::BitwiseAnd_16: m_stack.push(Value(lhs.value() & rhs.value())); break;
+                    case Opcode::BitwiseXor_16: m_stack.push(Value(lhs.value() ^ rhs.value())); break;
+                    default: XCI_UNREACHABLE;
+                }
                 break;
             }
-            case Opcode::BitwiseOr_32: {
-                auto lhs = m_stack.pull<value::UInt32>();
-                auto rhs = m_stack.pull<value::UInt32>();
-                m_stack.push(lhs.binary_op<std::bit_or<>, true>(rhs));
-                break;
-            }
-            case Opcode::BitwiseAnd_32: {
-                auto lhs = m_stack.pull<value::UInt32>();
-                auto rhs = m_stack.pull<value::UInt32>();
-                m_stack.push(lhs.binary_op<std::bit_and<>, true>(rhs));
-                break;
-            }
+            case Opcode::BitwiseOr_32:
+            case Opcode::BitwiseAnd_32:
             case Opcode::BitwiseXor_32: {
-                auto lhs = m_stack.pull<value::UInt32>();
-                auto rhs = m_stack.pull<value::UInt32>();
-                m_stack.push(lhs.binary_op<std::bit_xor<>, true>(rhs));
+                const auto lhs = m_stack.pull<value::UInt32>();
+                const auto rhs = m_stack.pull<value::UInt32>();
+                switch (opcode) {
+                    case Opcode::BitwiseOr_32:  m_stack.push(Value(lhs.value() | rhs.value())); break;
+                    case Opcode::BitwiseAnd_32: m_stack.push(Value(lhs.value() & rhs.value())); break;
+                    case Opcode::BitwiseXor_32: m_stack.push(Value(lhs.value() ^ rhs.value())); break;
+                    default: XCI_UNREACHABLE;
+                }
                 break;
             }
-            case Opcode::BitwiseOr_64: {
-                auto lhs = m_stack.pull<value::UInt64>();
-                auto rhs = m_stack.pull<value::UInt64>();
-                m_stack.push(lhs.binary_op<std::bit_or<>, true>(rhs));
-                break;
-            }
-            case Opcode::BitwiseAnd_64: {
-                auto lhs = m_stack.pull<value::UInt64>();
-                auto rhs = m_stack.pull<value::UInt64>();
-                m_stack.push(lhs.binary_op<std::bit_and<>, true>(rhs));
-                break;
-            }
+            case Opcode::BitwiseOr_64:
+            case Opcode::BitwiseAnd_64:
             case Opcode::BitwiseXor_64: {
-                auto lhs = m_stack.pull<value::UInt64>();
-                auto rhs = m_stack.pull<value::UInt64>();
-                m_stack.push(lhs.binary_op<std::bit_xor<>, true>(rhs));
+                const auto lhs = m_stack.pull<value::UInt64>();
+                const auto rhs = m_stack.pull<value::UInt64>();
+                switch (opcode) {
+                    case Opcode::BitwiseOr_64:  m_stack.push(Value(lhs.value() | rhs.value())); break;
+                    case Opcode::BitwiseAnd_64: m_stack.push(Value(lhs.value() & rhs.value())); break;
+                    case Opcode::BitwiseXor_64: m_stack.push(Value(lhs.value() ^ rhs.value())); break;
+                    default: XCI_UNREACHABLE;
+                }
                 break;
             }
-            case Opcode::BitwiseOr_128: {
-                auto lhs = m_stack.pull<value::UInt128>();
-                auto rhs = m_stack.pull<value::UInt128>();
-                m_stack.push(lhs.binary_op<std::bit_or<>, true>(rhs));
-                break;
-            }
-            case Opcode::BitwiseAnd_128: {
-                auto lhs = m_stack.pull<value::UInt128>();
-                auto rhs = m_stack.pull<value::UInt128>();
-                m_stack.push(lhs.binary_op<std::bit_and<>, true>(rhs));
-                break;
-            }
+            case Opcode::BitwiseOr_128:
+            case Opcode::BitwiseAnd_128:
             case Opcode::BitwiseXor_128: {
-                auto lhs = m_stack.pull<value::UInt128>();
-                auto rhs = m_stack.pull<value::UInt128>();
-                m_stack.push(lhs.binary_op<std::bit_xor<>, true>(rhs));
+                const auto lhs = m_stack.pull<value::UInt128>();
+                const auto rhs = m_stack.pull<value::UInt128>();
+                switch (opcode) {
+                    case Opcode::BitwiseOr_128:  m_stack.push(Value(lhs.value() | rhs.value())); break;
+                    case Opcode::BitwiseAnd_128: m_stack.push(Value(lhs.value() & rhs.value())); break;
+                    case Opcode::BitwiseXor_128: m_stack.push(Value(lhs.value() ^ rhs.value())); break;
+                    default: XCI_UNREACHABLE;
+                }
                 break;
             }
 

--- a/src/xci/script/Value.cpp
+++ b/src/xci/script/Value.cpp
@@ -170,7 +170,7 @@ size_t Value::read(const byte* buffer)
 }
 
 
-size_t Value::size_on_stack() const
+size_t Value::size_on_stack() const noexcept
 {
     static_assert(sizeof(bool) == 1);
     return std::visit([](auto&& v) -> size_t {

--- a/src/xci/script/Value.h
+++ b/src/xci/script/Value.h
@@ -270,17 +270,17 @@ public:
 
     bool negate();  // unary minus op
 
-    template <class TBinFun>
-    Value binary_op(const Value& rhs) {
-        return std::visit([&rhs](const auto& l) -> Value {
+    template <class F>
+    Value binary_op(const Value& rhs, F&& f) {
+        return std::visit([&rhs, &f](const auto& l) -> Value {
             using T = std::decay_t<decltype(l)>;
             if constexpr ((std::is_floating_point_v<T> ||
                            std::is_integral_v<T> ||
                            std::is_same_v<T, uint128> || std::is_same_v<T, int128>
-                          ) && !std::is_same_v<T, bool>)
+                          ) && !std::is_same_v<T, bool> && !std::is_same_v<T, char32_t>)
             {
                 if (std::holds_alternative<T>(rhs.m_value))
-                    return Value(TBinFun{}(l, rhs.get<T>()));
+                    return f(l, rhs.get<T>());
             }
             XCI_UNREACHABLE;
         }, m_value);

--- a/src/xci/script/ast/resolve_decl.cpp
+++ b/src/xci/script/ast/resolve_decl.cpp
@@ -335,7 +335,7 @@ public:
                 for (const auto& [i, sp] : spec.subtypes() | enumerate) {
                     auto& par = param.subtypes()[i];
                     if (par.is_unknown()) {
-                        par.assign_from(sp);
+                        par.copy_from_no_key(sp);
                     } else {
                         auto m = match_type(par, sp);
                         if (!m)

--- a/src/xci/script/typing/generic_resolver.cpp
+++ b/src/xci/script/typing/generic_resolver.cpp
@@ -22,7 +22,7 @@ void set_type_arg(SymbolPointer var, const TypeInfo& deduced, TypeArgs& type_arg
         if (!match_type(existing, deduced))
             exc_cb(existing, deduced);
         if (existing.is_unspecified()) {
-            existing.assign_from(deduced);
+            existing.copy_from_no_key(deduced);
         } else if (existing.has_generic()) {
             specialize_arg(existing, deduced, type_args, exc_cb);
             resolve_generic_type(existing, type_args);
@@ -36,12 +36,12 @@ void get_type_arg(SymbolPointer var, TypeInfo& sig, const TypeArgs& type_args)
     for (;;) {
         auto ti = type_args.get(var);
         if (ti.is_generic()) {
-            sig.assign_from(ti);
+            sig.copy_from_no_key(ti);
             var = ti.generic_var();
             continue;
         }
         if (ti) {
-            sig.assign_from(ti);
+            sig.copy_from_no_key(ti);
         }
         break;
     }
@@ -76,7 +76,7 @@ void resolve_generic_type(TypeInfo& sig, const TypeArgs& type_args)
                 resolve_generic_type(sub, type_args);
             break;
         case Type::Function:
-            sig.assign_from(TypeInfo(std::make_shared<Signature>(sig.signature())));  // copy signature
+            sig.copy_from_no_key(TypeInfo(std::make_shared<Signature>(sig.signature())));  // copy signature
             resolve_generic_type(sig.signature().param_type, type_args);
             resolve_generic_type(sig.signature().return_type, type_args);
             break;
@@ -97,13 +97,13 @@ void resolve_generic_type(TypeInfo& sig, const Scope& scope)
                 for (;;) {
                     auto ti = scope_p->type_args().get(var);
                     if (ti.is_generic()) {
-                        sig.assign_from(ti);
+                        sig.copy_from_no_key(ti);
                         var = ti.generic_var();
                         scope_p = &scope;
                         continue;
                     }
                     if (ti) {
-                        sig.assign_from(ti);
+                        sig.copy_from_no_key(ti);
                         break;
                     }
                     if (!scope_p->parent())
@@ -122,7 +122,7 @@ void resolve_generic_type(TypeInfo& sig, const Scope& scope)
                 resolve_generic_type(sub, scope);
             break;
         case Type::Function:
-            sig.assign_from(TypeInfo(std::make_shared<Signature>(sig.signature())));  // copy signature
+            sig.copy_from_no_key(TypeInfo(std::make_shared<Signature>(sig.signature())));  // copy signature
             resolve_generic_type(sig.signature().param_type, scope);
             resolve_generic_type(sig.signature().return_type, scope);
             break;

--- a/tests/test_static_vec.cpp
+++ b/tests/test_static_vec.cpp
@@ -47,3 +47,18 @@ TEST_CASE( "Iterators", "[ChunkedStack]" )
         ++i;
     }
 }
+
+
+TEST_CASE( "Moved out", "[ChunkedStack]" )
+{
+    StaticVec<int> vec(3);
+    vec[0] = 1;
+    vec[1] = 2;
+    vec[2] = 3;
+    StaticVec<int> vec2 = std::move(vec);
+    CHECK(vec.size() == 0);  // NOLINT, intentional check after move
+    REQUIRE(vec2.size() == 3);
+    CHECK(vec2.front() == 1);
+    CHECK(vec2[1] == 2);
+    CHECK(vec2.back() == 3);
+}


### PR DESCRIPTION
With Clang MinSizeRel, saves 300kB of the `fire` binary (1.2M -> 900k). It was mostly wasted on the binary_op proliferation.
In theory, Clang could optimize this by itself, but even Clang 17 does not. E.g. Emscripten with Closure compiler is not affected - the binary did not get that much smaller.