### PR TITLE
[config] Config parser with custom syntax

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,7 @@ AllowShortFunctionsOnASingleLine: Inline
 BreakBeforeBraces: Custom
 BraceWrapping:
   AfterCaseLabel: false
-  AfterClass: true
+  AfterClass: false
   AfterControlStatement: MultiLine
   AfterEnum: false
   AfterFunction: true

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,8 @@
 xci-compat:
   - src/xci/compat/*.h
+xci-config:
+  - src/xci/config/*.+(cpp|h)
+  - src/xci/config/**/*.+(cpp|h)
 xci-core:
   - src/xci/core/*.+(cpp|h)
   - src/xci/core/**/*.+(cpp|h)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,6 @@ option(XCI_INSTALL_DEVEL "Install headers, CMake config, static libs." ON)
 # Dependencies
 option(XCI_WITH_TERMINFO "Link with TermInfo and use it for TTY control sequences, instead of builtin sequences." OFF)
 option(XCI_WITH_HYPERSCAN "Hyperscan library is required to build ff tool." OFF)
-option(XCI_WITH_PEGTL "PEGTL library is required to build xci-script." ON)
 
 # negate it for use as option() initial value
 if (EMSCRIPTEN)
@@ -101,9 +100,7 @@ else()
 endif()
 
 # PEGTL
-if (XCI_WITH_PEGTL)
-    find_package(pegtl REQUIRED)
-endif()
+find_package(pegtl REQUIRED)
 
 # range-v3
 if (XCI_SCRIPT OR XCI_GRAPHICS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # 3.18.4 in Debian 11
 # 3.22.1 in Ubuntu 22.04 / Emscripten Docker image
 # 3.25.1 in Debian 12
-cmake_minimum_required(VERSION 3.18...3.25)
+cmake_minimum_required(VERSION 3.18...3.27)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(XciBuildType)
@@ -16,6 +16,7 @@ include(GNUInstallDirs)
 
 # Optional libraries (only xci-core is required)
 include(CMakeDependentOption)
+option(XCI_CONFIG "Enable component: xci-config" ON)
 option(XCI_VFS "Enable component: xci-vfs" ON)
 option(XCI_WIDGETS "Enable component: xci-widgets" ON)
 option(XCI_SCRIPT "Enable component: xci-script" ON)
@@ -194,6 +195,10 @@ endif()
 
 add_subdirectory(src/xci/core)
 
+if (XCI_CONFIG)
+    add_subdirectory(src/xci/config)
+endif()
+
 if (XCI_VFS)
     add_subdirectory(src/xci/vfs)
 endif()
@@ -340,6 +345,7 @@ print_flag("? libraries!                   " ON)
 if (TRUE)
     push_indent()
     print_flag("? xci-core!                    " ON)
+    print_flag("? xci-config!                  " ${XCI_CONFIG})
     print_flag("? xci-vfs!                     " ${XCI_VFS})
     print_flag("? xci-data!                    " ${XCI_DATA})
     print_flag("? xci-script!                  " ${XCI_SCRIPT})

--- a/config.h.in
+++ b/config.h.in
@@ -9,7 +9,6 @@
 
 // Optional libraries
 #cmakedefine01 XCI_WITH_TERMINFO
-#cmakedefine01 XCI_WITH_PEGTL
 
 // Location of share dir (runtime data)
 #cmakedefine XCI_SHARE_DIR "@XCI_SHARE_DIR@"

--- a/src/xci/config/CMakeLists.txt
+++ b/src/xci/config/CMakeLists.txt
@@ -1,0 +1,32 @@
+# ------------------- #
+# Library: xci-config #
+# ------------------- #
+
+add_library(xci-config
+    Config.cpp
+    ConfigParser.cpp
+)
+add_library(xcikit::xci-config ALIAS xci-config)
+target_precompile_headers(xci-config REUSE_FROM xci-core)
+
+target_link_libraries(xci-config PUBLIC xci-core)
+target_include_directories(xci-config
+    PRIVATE $<TARGET_PROPERTY:taocpp::pegtl,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+
+if (BUILD_SHARED_LIBS)
+    set_target_properties(xci-config PROPERTIES CXX_VISIBILITY_PRESET default)
+endif()
+
+
+# ------- #
+# Install #
+# ------- #
+
+if (BUILD_SHARED_LIBS OR XCI_INSTALL_DEVEL)
+    install(TARGETS xci-config
+        EXPORT xcikit
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+endif()

--- a/src/xci/config/Config.cpp
+++ b/src/xci/config/Config.cpp
@@ -6,13 +6,97 @@
 
 #include "Config.h"
 #include "ConfigParser.h"
+#include <deque>
 
 namespace xci::config {
 
 
-class RetainedConfigParser : public ConfigParser {
+class RetainedConfigParser final : public ConfigParser {
+public:
+    explicit RetainedConfigParser(Config& config) : m_config(&config) {}
 
+protected:
+    void name(const std::string& name) override { m_config->add(name); }
+    void bool_value(bool value) override { m_config->back() = value; }
+    void int_value(int64_t value) override { m_config->back() = value; }
+    void float_value(double value) override { m_config->back() = value; }
+    void string_value(std::string value) override { m_config->back() = std::move(value); }
+
+    void begin_group() override {
+        m_config_stack.push_back(m_config);
+        m_config->back() = Config();
+        m_config = &m_config->back().as_group();
+    }
+    void end_group() override {
+        m_config = m_config_stack.back();
+        m_config_stack.pop_back();
+    }
+
+private:
+    Config* m_config;
+    std::deque<Config*> m_config_stack;
 };
+
+
+ConfigItem& Config::add(const std::string& name)
+{
+    m_items.push_back(ConfigItem(name));
+    return m_items.back();
+}
+
+
+ConfigItem& Config::set(const std::string& name)
+{
+    auto it = get_next(name);
+    if (it == end())
+        return add(name);
+    return *it;
+}
+
+
+template <class C, class I>
+static I _get_next(C& c, const std::string& name, I prev)
+{
+    if (prev == I{} || prev == c.end())
+        prev = c.begin();
+    else
+        ++prev;
+    return std::find_if(prev, c.end(),
+        [&name](const ConfigItem& v) { return v.name() == name; });
+}
+
+
+auto Config::get_next(const std::string& name, const_iterator prev) const -> const_iterator
+{
+    return _get_next(*this, name, prev);
+}
+
+
+auto Config::get_next(const std::string& name, iterator prev) -> iterator
+{
+    return _get_next(*this, name, prev);
+}
+
+
+ConfigItem& Config::back() noexcept { return m_items.back(); }
+const ConfigItem& Config::back() const noexcept { return m_items.back(); }
+ConfigItem& Config::front() noexcept { return m_items.front(); }
+const ConfigItem& Config::front() const noexcept { return m_items.front(); }
+size_t Config::size() const { return m_items.size(); }
+
+
+bool Config::parse_file(const fs::path& path)
+{
+    RetainedConfigParser p(*this);
+    return p.parse_file(path);
+}
+
+
+bool Config::parse_string(const std::string& str)
+{
+    RetainedConfigParser p(*this);
+    return p.parse_string(str);
+}
 
 
 }  // namespace xci::config

--- a/src/xci/config/Config.cpp
+++ b/src/xci/config/Config.cpp
@@ -1,0 +1,18 @@
+// Config.cpp created on 2023-11-08 as part of xcikit project
+// https://github.com/rbrich/xcikit
+//
+// Copyright 2023 Radek Brich
+// Licensed under the Apache License, Version 2.0 (see LICENSE file)
+
+#include "Config.h"
+#include "ConfigParser.h"
+
+namespace xci::config {
+
+
+class RetainedConfigParser : public ConfigParser {
+
+};
+
+
+}  // namespace xci::config

--- a/src/xci/config/Config.h
+++ b/src/xci/config/Config.h
@@ -7,25 +7,135 @@
 #ifndef XCI_CONFIG_H
 #define XCI_CONFIG_H
 
+#include <variant>
+#include <filesystem>
+
 namespace xci::config {
 
-struct ConfigItem;
+namespace fs = std::filesystem;
 
+
+struct ConfigItem;
 
 /// Retained config data
 /// Config can be created and edited in-memory, then serialized to file.
 /// Parsing facility is provided by `ConfigParser`, the supported syntax is documented there.
 class Config {
 public:
+    bool parse_file(const fs::path& path);
+    bool parse_string(const std::string& str);
+
+    ConfigItem& operator[](const std::string& name) { return set(name); }
+    const ConfigItem& operator[](const std::string& name) const { return get(name); }
+
+    /// Add item to the back. Does not check uniquiness.
+    ConfigItem& add(const std::string& name);
+
+    /// Find item, or add new null item if not found.
+    ConfigItem& set(const std::string& name);
+
+    /// Get existing item. UB if doesn't exist.
+    const ConfigItem& get(const std::string& name) const { return *get_next(name); }
+
+    using const_iterator = std::vector<ConfigItem>::const_iterator;
+    using iterator = std::vector<ConfigItem>::iterator;
+
+    const_iterator get_next(const std::string& name, const_iterator prev = const_iterator{}) const;
+    iterator get_next(const std::string& name, iterator prev = iterator{});
+
+    const_iterator begin() const noexcept { return m_items.begin(); }
+    const_iterator end() const noexcept { return m_items.end(); }
+    iterator begin() noexcept { return m_items.begin(); }
+    iterator end() noexcept { return m_items.end(); }
+
+    const ConfigItem& front() const noexcept;
+    const ConfigItem& back() const noexcept;
+    ConfigItem& front() noexcept;
+    ConfigItem& back() noexcept;
+
+    size_t size() const;
+    bool is_empty() const noexcept { return m_items.empty(); }
 
 private:
     std::vector<ConfigItem> m_items;
 };
 
 
+using ConfigValue = std::variant<std::monostate, bool, int64_t, double, std::string, Config>;
+
 struct ConfigItem {
-    std::string name;
-    std::variant<bool, int64_t, double, std::string, Config> value;
+    explicit ConfigItem(std::string name) : m_name(std::move(name)) {}
+
+    const std::string& name() const { return m_name; }
+    void set_name(std::string name) { m_name = std::move(name); }
+
+    template <typename T>
+    void operator= (T value) {
+        m_value = std::forward<T>(value);
+    }
+
+    ConfigItem& operator[](const std::string& name) { return is_group()? as_group()[name] : m_value.emplace<Config>()[name]; }
+    const ConfigItem& operator[](const std::string& name) const { return as_group()[name]; }
+
+
+    // Strict comparison, without conversion. If the type doesn't match, returns false.
+    bool operator== (bool value) const noexcept { return is_bool() && as_bool() == value; }
+    bool operator== (int value) const noexcept { return is_int() && as_int() == value; }
+    bool operator== (int64_t value) const noexcept { return is_int() && as_int() == value; }
+    bool operator== (double value) const noexcept { return is_float() && as_float() == value; }
+    bool operator== (const char* value) const noexcept { return is_string() && as_string() == value; }
+    bool operator== (std::string_view value) const noexcept { return is_string() && as_string() == value; }
+
+    // -------------------------------------------------------------------------
+    // Check type of value
+
+    /// The item is unset or discarded. Won't be serialized.
+    bool is_null() const { return std::holds_alternative<std::monostate>(m_value); }
+
+    bool is_bool() const { return std::holds_alternative<bool>(m_value); }
+    bool is_int() const { return std::holds_alternative<int64_t>(m_value); }
+    bool is_float() const { return std::holds_alternative<double>(m_value); }
+    bool is_string() const { return std::holds_alternative<std::string>(m_value); }
+    bool is_group() const { return std::holds_alternative<Config>(m_value); }
+
+    // -------------------------------------------------------------------------
+    // Access value - the actual type must match!
+
+    bool as_bool() { return std::get<bool>(m_value); }
+    int64_t as_int() { return std::get<int64_t>(m_value); }
+    double as_float() { return std::get<double>(m_value); }
+    std::string& as_string() { return std::get<std::string>(m_value); }
+    Config& as_group() { return std::get<Config>(m_value); }
+
+    bool as_bool() const { return std::get<bool>(m_value); }
+    int64_t as_int() const { return std::get<int64_t>(m_value); }
+    double as_float() const { return std::get<double>(m_value); }
+    const std::string& as_string() const { return std::get<std::string>(m_value); }
+    const Config& as_group() const { return std::get<Config>(m_value); }
+
+    // -------------------------------------------------------------------------
+    // Convert value
+
+    // For int and float, returns false if 0, otherwise true.
+    // String is converted to true only if "true", otherwise false.
+    bool to_bool() const { return std::get<bool>(m_value); }
+
+    // Bool is converted to 0 / 1.
+    // Float is truncated to int.
+    // String is parsed to int if possible, otherwise 0 (atoi).
+    int64_t to_int() const { return std::get<int64_t>(m_value); }
+
+    // Bool is converted to 0.0 / 1.0.
+    // String is parsed to float, 0 on failure.
+    double to_float() const { return std::get<double>(m_value); }
+
+    // Bool is converted to "false" / "true".
+    // Int/float is converted to string.
+    std::string to_string() const { return std::get<std::string>(m_value); }
+
+private:
+    std::string m_name;
+    ConfigValue m_value;
 };
 
 

--- a/src/xci/config/Config.h
+++ b/src/xci/config/Config.h
@@ -7,8 +7,10 @@
 #ifndef XCI_CONFIG_H
 #define XCI_CONFIG_H
 
+#include <vector>
 #include <variant>
 #include <filesystem>
+#include <ostream>
 
 namespace xci::config {
 
@@ -24,6 +26,10 @@ class Config {
 public:
     bool parse_file(const fs::path& path);
     bool parse_string(const std::string& str);
+
+    void dump(std::ostream& os) const;
+    std::string dump() const;
+    bool dump_to_file(const fs::path& path) const;
 
     ConfigItem& operator[](const std::string& name) { return set(name); }
     const ConfigItem& operator[](const std::string& name) const { return get(name); }
@@ -68,6 +74,9 @@ struct ConfigItem {
 
     const std::string& name() const { return m_name; }
     void set_name(std::string name) { m_name = std::move(name); }
+
+    template<class T> auto visit(T&& visitor) const { return std::visit(visitor, m_value); }
+    template<class T> auto visit(T&& visitor) { return std::visit(visitor, m_value); }
 
     template <typename T>
     void operator= (T value) {

--- a/src/xci/config/Config.h
+++ b/src/xci/config/Config.h
@@ -1,0 +1,34 @@
+// Config.h created on 2023-11-08 as part of xcikit project
+// https://github.com/rbrich/xcikit
+//
+// Copyright 2023 Radek Brich
+// Licensed under the Apache License, Version 2.0 (see LICENSE file)
+
+#ifndef XCI_CONFIG_H
+#define XCI_CONFIG_H
+
+namespace xci::config {
+
+struct ConfigItem;
+
+
+/// Retained config data
+/// Config can be created and edited in-memory, then serialized to file.
+/// Parsing facility is provided by `ConfigParser`, the supported syntax is documented there.
+class Config {
+public:
+
+private:
+    std::vector<ConfigItem> m_items;
+};
+
+
+struct ConfigItem {
+    std::string name;
+    std::variant<bool, int64_t, double, std::string, Config> value;
+};
+
+
+}  // namespace xci::config
+
+#endif  // XCI_CONFIG_H

--- a/src/xci/config/ConfigParser.cpp
+++ b/src/xci/config/ConfigParser.cpp
@@ -1,0 +1,121 @@
+// ConfigParser.cpp created on 2023-11-08 as part of xcikit project
+// https://github.com/rbrich/xcikit
+//
+// Copyright 2023 Radek Brich
+// Licensed under the Apache License, Version 2.0 (see LICENSE file)
+
+#include "ConfigParser.h"
+#include <xci/core/log.h>
+#include <xci/core/parser/unescape_rules.h>
+
+#include <tao/pegtl.hpp>
+#include <fmt/ostream.h>
+
+namespace xci::config {
+
+using namespace xci::core;
+
+namespace parser {
+
+using namespace tao::pegtl;
+using namespace xci::core::parser::unescape;
+
+// ----------------------------------------------------------------------------
+// Grammar
+
+// Spaces and comments
+struct LineComment: seq< two<'/'>, until<eolf> > {};
+struct SkipWS: star<sor<space, LineComment>> {};
+struct SemicolonOrNewline: sor<one<';'>, eolf, LineComment> {};
+struct Sep: seq<star<blank>, SemicolonOrNewline> {};
+
+// Keywords
+struct KFalse: TAO_PEGTL_KEYWORD("false") {};
+struct KTrue: TAO_PEGTL_KEYWORD("true") {};
+
+// Literals
+template<class D> struct UPlus: seq< D, star<opt<one<'_'>>, D> > {};  // one or more digits D interleaved by underscores ('_')
+struct Sign: one<'-','+'> {};
+struct DecNumFrac: seq< one<'.'>, opt<UPlus<digit>> > {};
+struct DecNumExp: seq< one<'e'>, opt<Sign>, must<UPlus<digit>> > {};
+
+// Values
+struct Bool: sor<KFalse, KTrue> {};
+struct Number: seq<opt<Sign>, UPlus<digit>, opt<DecNumFrac>, opt<DecNumExp>> {};
+struct StringContent: until< one<'"'>, StringChUni > {};
+struct String: if_must< one<'"'>, StringContent > {};
+
+// Group
+struct GroupContent;
+struct Group: seq<one<'{'>, GroupContent, SkipWS, one<'}'>> {};
+
+// Item
+struct Name: identifier {};
+struct Value: sor<Bool, Number, String, Group> {};
+struct Item: seq<SkipWS, Name, plus<blank>, Value, Sep> {};
+
+// File
+struct GroupContent: star<Item> {};
+struct FileContent: seq<GroupContent, SkipWS, eof> {};
+
+
+// ----------------------------------------------------------------------------
+// Actions
+
+template<typename Rule>
+struct Action : nothing<Rule> {};
+
+template<>
+struct Action<Name> {
+    template<typename Input>
+    static void apply(const Input& in, ConfigParser& visitor) {
+        visitor.name(in.string());
+    }
+};
+
+template<>
+struct Action<Bool> {
+    template<typename Input>
+    static void apply(const Input& in, ConfigParser& visitor) {
+        visitor.bool_value(in.string() == "true");
+    }
+};
+
+
+// ----------------------------------------------------------------------------
+// Control (error reporting)
+
+template< typename Rule >
+struct Control : normal< Rule >
+{
+    template< typename Input, typename... States >
+    static void raise( const Input& in, States&&... /*unused*/ )
+    {
+        log::error("{}: Parse error matching {} at [{}]",
+                   fmt::streamed(in.position()),
+                   demangle<Rule>(),
+                   std::string(in.current(), in.size()).substr(0, 10));
+        throw parse_error( "parse error matching " + std::string(demangle<Rule>()), in );
+    }
+};
+
+} // namespace parser
+
+
+bool ConfigParser::parse_string(const std::string &str)
+{
+    using parser::FileContent;
+    using parser::Action;
+    using parser::Control;
+
+    tao::pegtl::memory_input<> in(str, "<buffer>");
+
+    try {
+        return tao::pegtl::parse< FileContent, Action, Control >( in, *this );
+    } catch (const tao::pegtl::parse_error&) {
+        return false;
+    }
+}
+
+
+}  // namespace xci::config

--- a/src/xci/config/ConfigParser.cpp
+++ b/src/xci/config/ConfigParser.cpp
@@ -178,21 +178,33 @@ struct Control : normal< Rule >
 } // namespace parser
 
 
-bool ConfigParser::parse_string(const std::string &str)
+template<class T>
+static bool _parse(ConfigParser& config_parser, T&& in)
 {
     using parser::FileContent;
     using parser::Action;
     using parser::Control;
-
-    tao::pegtl::memory_input in(str, "<buffer>");
-
     try {
-        return tao::pegtl::parse< FileContent, Action, Control >( in, *this );
+        return tao::pegtl::parse< FileContent, Action, Control >( in, config_parser );
     } catch (const tao::pegtl::parse_error& e) {
         const auto& p = e.positions().front();
         log::error("{}\n:{}\n{:>{}}", e.what(), in.line_at(p), '^', p.column);
         return false;
     }
+}
+
+
+bool ConfigParser::parse_file(const fs::path& path)
+{
+    tao::pegtl::file_input in(path);
+    return _parse(*this, in);
+}
+
+
+bool ConfigParser::parse_string(const std::string &str)
+{
+    tao::pegtl::memory_input in(str, "<buffer>");
+    return _parse(*this, in);
 }
 
 

--- a/src/xci/config/ConfigParser.h
+++ b/src/xci/config/ConfigParser.h
@@ -1,0 +1,44 @@
+// ConfigParser.h created on 2023-11-08 as part of xcikit project
+// https://github.com/rbrich/xcikit
+//
+// Copyright 2023 Radek Brich
+// Licensed under the Apache License, Version 2.0 (see LICENSE file)
+
+#ifndef XCI_CONFIG_PARSER_H
+#define XCI_CONFIG_PARSER_H
+
+#include <string>
+#include <variant>
+#include <filesystem>
+
+namespace xci::config {
+
+namespace fs = std::filesystem;
+
+
+/// The config format:
+/// ```
+/// bool_item false   // true/false
+/// int_item 1
+/// float_item 2.3
+/// string_item "abc\n"  // quotes are required, supports C-style escape sequences
+/// group {
+///   value 1
+///   subgroup { foo 42; bar "baz" }  // semicolon is used as a delimiter for multiple items on same line
+/// }
+/// ```
+/// Whitespace is required between item name and value. Value must start on same line as name.
+class ConfigParser {
+public:
+    bool parse_file(const fs::path& path);
+    bool parse_string(const std::string& str);
+
+    // visitor callbacks
+    virtual void name(const std::string& name) = 0;
+    virtual void bool_value(bool value) = 0;
+};
+
+
+}  // namespace xci::config
+
+#endif  // XCI_CONFIG_PARSER_H

--- a/src/xci/config/ConfigParser.h
+++ b/src/xci/config/ConfigParser.h
@@ -37,7 +37,8 @@ public:
     // visitor callbacks
 
     virtual void name(const std::string& name) = 0;
-    virtual void group(bool begin) = 0;
+    virtual void begin_group() = 0;
+    virtual void end_group() = 0;
 
     virtual void bool_value(bool value) = 0;
     virtual void int_value(int64_t value) = 0;

--- a/src/xci/config/ConfigParser.h
+++ b/src/xci/config/ConfigParser.h
@@ -8,7 +8,6 @@
 #define XCI_CONFIG_PARSER_H
 
 #include <string>
-#include <variant>
 #include <filesystem>
 
 namespace xci::config {
@@ -30,12 +29,20 @@ namespace fs = std::filesystem;
 /// Whitespace is required between item name and value. Value must start on same line as name.
 class ConfigParser {
 public:
+    virtual ~ConfigParser() = default;
+
     bool parse_file(const fs::path& path);
     bool parse_string(const std::string& str);
 
     // visitor callbacks
+
     virtual void name(const std::string& name) = 0;
+    virtual void group(bool begin) = 0;
+
     virtual void bool_value(bool value) = 0;
+    virtual void int_value(int64_t value) = 0;
+    virtual void float_value(double value) = 0;
+    virtual void string_value(std::string value) = 0;
 };
 
 

--- a/src/xci/core/CMakeLists.txt
+++ b/src/xci/core/CMakeLists.txt
@@ -83,14 +83,8 @@ target_include_directories(xci-core
         ${XCI_INCLUDE_DIRS}
     PRIVATE
         $<TARGET_PROPERTY:third_party::widechar_width,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:taocpp::pegtl,INTERFACE_INCLUDE_DIRECTORIES>
     )
-
-if (XCI_WITH_PEGTL)
-    target_include_directories(xci-core
-        PRIVATE
-            $<TARGET_PROPERTY:taocpp::pegtl,INTERFACE_INCLUDE_DIRECTORIES>
-        )
-endif()
 
 # Link with tinfo if available
 if (XCI_WITH_TERMINFO)

--- a/src/xci/core/string.cpp
+++ b/src/xci/core/string.cpp
@@ -6,9 +6,7 @@
 
 #include "string.h"
 
-#if XCI_WITH_PEGTL == 1
 #include "parser/unescape.h"
-#endif
 
 #include <xci/core/log.h>
 #include <xci/compat/macros.h>
@@ -152,7 +150,6 @@ std::string escape(string_view str, bool extended, bool utf8)
 }
 
 
-#if XCI_WITH_PEGTL == 1
 // override control to avoid demangled rules appearing in binary static data
 // (even though they're never used, they don't get optimized away)
 template< typename Rule >
@@ -188,7 +185,6 @@ std::string gen_unescape(string_view str)
 
 std::string unescape(string_view str) { return gen_unescape<parser::unescape::String>(str); }
 std::string unescape_uni(string_view str) { return gen_unescape<parser::unescape::StringUni>(str); }
-#endif
 
 
 std::string to_lower(std::string_view str)

--- a/src/xci/core/string.h
+++ b/src/xci/core/string.h
@@ -116,7 +116,6 @@ void strip(S& str) { lstrip(str); rstrip(str); }
 std::string escape(std::string_view str, bool extended = false, bool utf8 = false);
 inline std::string escape_utf8(std::string_view str, bool extended = false) { return escape(str, extended, true); }
 
-#if XCI_WITH_PEGTL == 1
 // Unescape (expand) C escape sequences (i.e. "\\n" -> "\n")
 // This expects the input is well-formatted:
 // - a trailing backslash is just ignored
@@ -125,7 +124,6 @@ std::string unescape(std::string_view str);
 
 // Same as unescape, with additional support for braced unicode escapes: "\u{ABCD}"
 std::string unescape_uni(std::string_view str);
-#endif
 
 // Convert string to lower case
 std::string to_lower(std::string_view str);

--- a/src/xci/vfs/CMakeLists.txt
+++ b/src/xci/vfs/CMakeLists.txt
@@ -2,25 +2,23 @@
 # Library: xci-vfs #
 # ---------------- #
 
-if (XCI_VFS)
-    add_library(xci-vfs
-        Vfs.cpp
-        RealDirectory.cpp
-        DarArchive.cpp
-        WadArchive.cpp
-        ZipArchive.cpp
-    )
-    add_library(xcikit::xci-vfs ALIAS xci-vfs)
-    target_precompile_headers(xci-vfs REUSE_FROM xci-core)
-    target_link_libraries(xci-vfs PUBLIC xci-core)
-    if (BUILD_SHARED_LIBS)
-        set_target_properties(xci-vfs PROPERTIES CXX_VISIBILITY_PRESET default)
-    endif()
+add_library(xci-vfs
+    Vfs.cpp
+    RealDirectory.cpp
+    DarArchive.cpp
+    WadArchive.cpp
+    ZipArchive.cpp
+)
+add_library(xcikit::xci-vfs ALIAS xci-vfs)
+target_precompile_headers(xci-vfs REUSE_FROM xci-core)
+target_link_libraries(xci-vfs PUBLIC xci-core)
+if (BUILD_SHARED_LIBS)
+    set_target_properties(xci-vfs PROPERTIES CXX_VISIBILITY_PRESET default)
+endif()
 
-    # VFS requires libzip
-    find_package(libzip REQUIRED)
-    target_link_libraries(xci-vfs PRIVATE libzip::zip)
-endif ()
+# VFS requires libzip
+find_package(libzip REQUIRED)
+target_link_libraries(xci-vfs PRIVATE libzip::zip)
 
 
 # ------- #

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,10 @@ if (NOT EMSCRIPTEN)
     add_catch_test(test_eventloop test_eventloop.cpp xci-core)
 endif()
 
+if (XCI_CONFIG)
+    add_catch_test(test_config test_config.cpp xci-config)
+endif()
+
 if (XCI_DATA)
     add_catch_test(test_data test_data.cpp xci-data)
     add_catch_test(test_data_binary test_data_binary.cpp xci-data)

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -77,8 +77,8 @@ TEST_CASE( "Config syntax", "[ConfigParser]" )
 TEST_CASE( "Config", "[Config]" )
 {
     Config c;
-    CHECK(c.parse_string("bool_item false; int_item 1; float_item 2.3; string_item \"abc\\n\";"
-                         "group { value 2; subgroup { foo 42; bar \"baz\" } }"));
+    CHECK(c.parse_string("bool_item false\nint_item 1;\nfloat_item 2.3; string_item \"abc\\n\";"
+                         "group { value 2; subgroup { foo 42; bar \"baz\"; } }"));
     CHECK(c.size() == 5);
     CHECK(c.front().name() == "bool_item");
     CHECK(c.front().as_bool() == false);
@@ -97,4 +97,19 @@ TEST_CASE( "Config", "[Config]" )
     CHECK(c["group"]["value"].is_group());
     CHECK(c["group"]["value"].as_group().size() == 1);  // "subvalue" item was created
     CHECK(c["group"]["value"]["subvalue"].is_null());
+
+    // Serialization
+    CHECK(c.dump() ==
+        "bool_item false\n"
+        "int_item \"42x\"\n"
+        "float_item 2.3\n"
+        "string_item \"abc\\n\"\n"
+        "group {\n"
+        "  value {\n"
+        "  }\n"
+        "  subgroup {\n"
+        "    foo 42\n"
+        "    bar \"baz\"\n"
+        "  }\n"
+        "}\n");
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -9,10 +9,12 @@
 
 #include <xci/config/ConfigParser.h>
 #include <xci/config/Config.h>
+#include <xci/core/string.h>
 
 #include <sstream>
 
 using namespace xci::config;
+using namespace xci::core;
 
 
 class TestConfigParser : public ConfigParser {
@@ -21,16 +23,30 @@ public:
         if (!parse_string(str))
             dump << "<parse error>";
         auto res = dump.str();
-        dump.clear();
+        dump.str("");
         return res;
     }
 
 protected:
-    void name(const std::string& name) override { dump << name << ' '; }
-    void bool_value(bool value) override { dump << std::boolalpha << value; }
+    std::string indent() const { return std::string(m_indent * 2, ' '); }
+    void name(const std::string& name) override { dump << indent() << name << ' '; }
+    void bool_value(bool value) override { dump << std::boolalpha << value << '\n'; }
+    void int_value(int64_t value) override { dump << value << '\n'; }
+    void float_value(double value) override { dump << value << '\n'; }
+    void string_value(std::string value) override { dump << '"' << escape_utf8(value) << '"' << '\n'; }
+    void group(bool begin) override {
+        if (begin) {
+            ++m_indent;
+            dump << '{' << '\n';
+        } else {
+            --m_indent;
+            dump << indent() << '}' << '\n';
+        }
+    }
 
 private:
     std::stringstream dump;
+    int m_indent = 0;
 };
 
 
@@ -39,5 +55,21 @@ TEST_CASE( "Config syntax", "[ConfigParser]" )
     TestConfigParser p;
 
     CHECK(p("") == "");
-    CHECK(p("bool_item false") == "bool_item false");
+    CHECK(p("bool_item false") == "bool_item false\n");
+    CHECK(p("int_item 123") == "int_item 123\n");
+    CHECK(p("int_item 4.56") == "int_item 4.56\n");
+    CHECK(p("string_item \"abc\"") == "string_item \"abc\"\n");
+    CHECK(p("int_item 1\nbool_item true") == "int_item 1\nbool_item true\n");
+    CHECK(p("int_item 1; bool_item true") == "int_item 1\nbool_item true\n");
+    CHECK(p("group {}") == "group {\n}\n");
+    CHECK(p("group { value 1 }") == "group {\n  value 1\n}\n");
+    CHECK(p("group { value 1; value 2 }") == "group {\n  value 1\n  value 2\n}\n");
+    CHECK(p("group { value 1; subgroup { foo 42; bar \"baz\" } }") ==
+        "group {\n"
+        "  value 1\n"
+        "  subgroup {\n"
+        "    foo 42\n"
+        "    bar \"baz\"\n"
+        "  }\n"
+        "}\n");
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,0 +1,43 @@
+// test_config.cpp created on 2023-11-08 as part of xcikit project
+// https://github.com/rbrich/xcikit
+//
+// Copyright 2023 Radek Brich
+// Licensed under the Apache License, Version 2.0 (see LICENSE file)
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/generators/catch_generators.hpp>
+
+#include <xci/config/ConfigParser.h>
+#include <xci/config/Config.h>
+
+#include <sstream>
+
+using namespace xci::config;
+
+
+class TestConfigParser : public ConfigParser {
+public:
+    std::string operator()(const std::string& str) {
+        if (!parse_string(str))
+            dump << "<parse error>";
+        auto res = dump.str();
+        dump.clear();
+        return res;
+    }
+
+protected:
+    void name(const std::string& name) override { dump << name << ' '; }
+    void bool_value(bool value) override { dump << std::boolalpha << value; }
+
+private:
+    std::stringstream dump;
+};
+
+
+TEST_CASE( "Config syntax", "[ConfigParser]" )
+{
+    TestConfigParser p;
+
+    CHECK(p("") == "");
+    CHECK(p("bool_item false") == "bool_item false");
+}


### PR DESCRIPTION
It's like JSON, but for humans.

```
bool_item false   // true/false
int_item 1
float_item 2.3
string_item "abc\n"  // quotes are required, supports C-style escape sequences
group {
  value 1
  subgroup { foo 42; bar "baz" }  // semicolon is used as a delimiter for multiple items on same line
}
```

The syntax is strictly the above:
* Item names are "identifiers": `[A-Za-z_][A-Za-z0-9_]*`
* Optional semicolon can be used to delimit items instead of newline.
* Whitespace doesn't matter, except between item name and value, where at least one whitespace character is required (even between group name and `{`).
* Item names can repeated and the order is preserved. It's possible to list the items in original order and assign meaning to the repeated items (e.g. make a list from them).
* Arrays are not supported (Might be added in future).
* Only line comments are supported, no block comments.

The syntax can be extended to make it partially compatible with JSON (except JSON with something else than an object as top-level value):
* Allow `:` as alternative name-value delimiter.
* Allow quoted names.
* Allow top-level anonymous group (`{ ... }`)
* Support arrays