### PR TITLE
[core] TermCtl: A custom parser to replace color and mode placeholders in print/format

### DIFF
--- a/examples/core/demo_termctl.cpp
+++ b/examples/core/demo_termctl.cpp
@@ -27,17 +27,17 @@ int main()
 
     cout << t.move_up().move_right(6).bold().green() << "GREEN" <<t.normal() << endl;
 
-    t.print("<t:bold><fg:yellow>formatted<t:normal>\n");
-    t.print("<t:bold>bold<t:normal_intensity> "
-            "<t:dim>dim<t:normal_intensity> "
-            "<t:italic>italic<t:no_italic> "
-            "<t:underline>underlined<t:no_underline> "
-            "<t:overline>overlined<t:no_overline> "
-            "<t:cross_out>crossed out<t:no_cross_out> "
-            "<t:frame>framed<t:no_frame> "
-            "<t:blink>blinking<t:no_blink> "
-            "<t:reverse>reversed<t:no_reverse> "
-            "<t:hidden>hidden<t:no_hidden> "
+    t.print("<b><fg:yellow>formatted<n>\n");
+    t.print("<bold>bold<normal_intensity> "
+            "<dim>dim<normal_intensity> "
+            "<italic>italic<no_italic> "
+            "<underline>underlined<no_underline> "
+            "<overline>overlined<no_overline> "
+            "<cross_out>crossed out<no_cross_out> "
+            "<frame>framed<no_frame> "
+            "<blink>blinking<no_blink> "
+            "<reverse>reversed<no_reverse> "
+            "<hidden>hidden<no_hidden> "
             "\n");
 
     t.tab_set_all({30, 20}).write();

--- a/examples/core/demo_termctl.cpp
+++ b/examples/core/demo_termctl.cpp
@@ -1,7 +1,7 @@
 // demo_termctl.cpp created on 2018-07-11 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2018, 2020 Radek Brich
+// Copyright 2018–2024 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include <xci/core/TermCtl.h>
@@ -27,17 +27,17 @@ int main()
 
     cout << t.move_up().move_right(6).bold().green() << "GREEN" <<t.normal() << endl;
 
-    t.print("{t:bold}{fg:yellow}formatted{t:normal}\n");
-    t.print("{t:bold}bold{t:normal_intensity} "
-            "{t:dim}dim{t:normal_intensity} "
-            "{t:italic}italic{t:no_italic} "
-            "{t:underline}underlined{t:no_underline} "
-            "{t:overline}overlined{t:no_overline} "
-            "{t:cross_out}crossed out{t:no_cross_out} "
-            "{t:frame}framed{t:no_frame} "
-            "{t:blink}blinking{t:no_blink} "
-            "{t:reverse}reversed{t:no_reverse} "
-            "{t:hidden}hidden{t:no_hidden} "
+    t.print("<t:bold><fg:yellow>formatted<t:normal>\n");
+    t.print("<t:bold>bold<t:normal_intensity> "
+            "<t:dim>dim<t:normal_intensity> "
+            "<t:italic>italic<t:no_italic> "
+            "<t:underline>underlined<t:no_underline> "
+            "<t:overline>overlined<t:no_overline> "
+            "<t:cross_out>crossed out<t:no_cross_out> "
+            "<t:frame>framed<t:no_frame> "
+            "<t:blink>blinking<t:no_blink> "
+            "<t:reverse>reversed<t:no_reverse> "
+            "<t:hidden>hidden<t:no_hidden> "
             "\n");
 
     t.tab_set_all({30, 20}).write();

--- a/examples/core/demo_termctl.cpp
+++ b/examples/core/demo_termctl.cpp
@@ -27,7 +27,7 @@ int main()
 
     cout << t.move_up().move_right(6).bold().green() << "GREEN" <<t.normal() << endl;
 
-    t.print("<b><fg:yellow>formatted<n>\n");
+    t.print("<b><yellow>formatted <*white><@yellow> bg <n>\n");
     t.print("<bold>bold<normal_intensity> "
             "<dim>dim<normal_intensity> "
             "<italic>italic<no_italic> "

--- a/examples/core/demo_termctl.cpp
+++ b/examples/core/demo_termctl.cpp
@@ -39,6 +39,7 @@ int main()
             "<reverse>reversed<no_reverse> "
             "<hidden>hidden<no_hidden> "
             "\n");
+    t.print("Escaped \\<bold>. Unknown <tag>.\n");
 
     t.tab_set_all({30, 20}).write();
     t.print("tab stops:\t1\t2\n");

--- a/src/xci/core/ArgParser.cpp
+++ b/src/xci/core/ArgParser.cpp
@@ -136,12 +136,12 @@ std::string Option::usage() const
         if (!p)
             break;
         if (is_remainder() && p.dashes == 2 && p.len == 0) {
-            res += t.format("[<fg:green>{}<normal>] ", std::string(dp + p.pos, p.dashes));
+            res += t.format("[<green>{}<normal>] ", std::string(dp + p.pos, p.dashes));
         } else if (first) {
             first = false;
-            res += t.format("<bold><fg:green>{}<normal>", std::string(dp + p.pos, p.dashes + p.len));
+            res += t.format("<bold><green>{}<normal>", std::string(dp + p.pos, p.dashes + p.len));
         } else if (!p.dashes) {
-            res += t.format(" <fg:green>{}<normal>", std::string(dp + p.pos, p.len));
+            res += t.format(" <green>{}<normal>", std::string(dp + p.pos, p.len));
         }
         dp += p.end();
     }
@@ -312,7 +312,7 @@ ArgParser& ArgParser::operator()(const char* argv[], bool detect_width, unsigned
     if (!parse_program_name(argv[0])) {
         // this should not occur
         auto& t = TermCtl::stderr_instance();
-        t.print("<bold><fg:red>Missing program name (argv[0])<normal>\n");
+        t.print("<bold><red>Missing program name (argv[0])<normal>\n");
         exit(1);
     }
     try {
@@ -326,7 +326,7 @@ ArgParser& ArgParser::operator()(const char* argv[], bool detect_width, unsigned
         }
     } catch (const BadArgument& e) {
         auto& t = TermCtl::stderr_instance();
-        t.print("<bold><fg:yellow>Error: <fg:red>{}<normal>\n\n", e.what());
+        t.print("<bold><yellow>Error: <red>{}<normal>\n\n", e.what());
         print_usage();
         print_help_notice();
         exit(1);
@@ -525,7 +525,7 @@ void ArgParser::print_usage() const
 
     unsigned indent = 0;
     {
-        auto head = t.format("<bold><fg:yellow>Usage:<normal> <bold>{}<normal> ", m_progname);
+        auto head = t.format("<bold><yellow>Usage:<normal> <bold>{}<normal> ", m_progname);
         indent = TermCtl::stripped_width(head);
         cout << head;
     }
@@ -545,7 +545,7 @@ void ArgParser::print_help() const
         desc_cols = std::max(desc_cols, (unsigned) opt.desc().size());
     print_usage();
     auto& t = TermCtl::stdout_instance();
-    t.print("\n<bold><fg:yellow>Options:<normal>\n");
+    t.print("\n<bold><yellow>Options:<normal>\n");
     for (const auto& opt : m_opts) {
         cout << "  " << opt.formatted_desc(desc_cols) << "  ";
         wrapping_print(opt.help(), desc_cols + 4, 0, m_max_width);

--- a/src/xci/core/ArgParser.cpp
+++ b/src/xci/core/ArgParser.cpp
@@ -136,12 +136,12 @@ std::string Option::usage() const
         if (!p)
             break;
         if (is_remainder() && p.dashes == 2 && p.len == 0) {
-            res += t.format("[{fg:green}{}{t:normal}] ", std::string(dp + p.pos, p.dashes));
+            res += t.format("[<fg:green>{}<t:normal>] ", std::string(dp + p.pos, p.dashes));
         } else if (first) {
             first = false;
-            res += t.format("{t:bold}{fg:green}{}{t:normal}", std::string(dp + p.pos, p.dashes + p.len));
+            res += t.format("<t:bold><fg:green>{}<t:normal>", std::string(dp + p.pos, p.dashes + p.len));
         } else if (!p.dashes) {
-            res += t.format(" {fg:green}{}{t:normal}", std::string(dp + p.pos, p.len));
+            res += t.format(" <fg:green>{}<t:normal>", std::string(dp + p.pos, p.len));
         }
         dp += p.end();
     }
@@ -312,7 +312,7 @@ ArgParser& ArgParser::operator()(const char* argv[], bool detect_width, unsigned
     if (!parse_program_name(argv[0])) {
         // this should not occur
         auto& t = TermCtl::stderr_instance();
-        t.print("{t:bold}{fg:red}Missing program name (argv[0]){t:normal}\n");
+        t.print("<t:bold><fg:red>Missing program name (argv[0])<t:normal>\n");
         exit(1);
     }
     try {
@@ -326,7 +326,7 @@ ArgParser& ArgParser::operator()(const char* argv[], bool detect_width, unsigned
         }
     } catch (const BadArgument& e) {
         auto& t = TermCtl::stderr_instance();
-        t.print("{t:bold}{fg:yellow}Error: {fg:red}{}{t:normal}\n\n", e.what());
+        t.print("<t:bold><fg:yellow>Error: <fg:red>{}<t:normal>\n\n", e.what());
         print_usage();
         print_help_notice();
         exit(1);
@@ -525,7 +525,7 @@ void ArgParser::print_usage() const
 
     unsigned indent = 0;
     {
-        auto head = t.format("{t:bold}{fg:yellow}Usage:{t:normal} {t:bold}{}{t:normal} ", m_progname);
+        auto head = t.format("<t:bold><fg:yellow>Usage:<t:normal> <t:bold>{}<t:normal> ", m_progname);
         indent = TermCtl::stripped_width(head);
         cout << head;
     }
@@ -545,7 +545,7 @@ void ArgParser::print_help() const
         desc_cols = std::max(desc_cols, (unsigned) opt.desc().size());
     print_usage();
     auto& t = TermCtl::stdout_instance();
-    t.print("\n{t:bold}{fg:yellow}Options:{t:normal}\n");
+    t.print("\n<t:bold><fg:yellow>Options:<t:normal>\n");
     for (const auto& opt : m_opts) {
         cout << "  " << opt.formatted_desc(desc_cols) << "  ";
         wrapping_print(opt.help(), desc_cols + 4, 0, m_max_width);

--- a/src/xci/core/ArgParser.cpp
+++ b/src/xci/core/ArgParser.cpp
@@ -136,12 +136,12 @@ std::string Option::usage() const
         if (!p)
             break;
         if (is_remainder() && p.dashes == 2 && p.len == 0) {
-            res += t.format("[<fg:green>{}<t:normal>] ", std::string(dp + p.pos, p.dashes));
+            res += t.format("[<fg:green>{}<normal>] ", std::string(dp + p.pos, p.dashes));
         } else if (first) {
             first = false;
-            res += t.format("<t:bold><fg:green>{}<t:normal>", std::string(dp + p.pos, p.dashes + p.len));
+            res += t.format("<bold><fg:green>{}<normal>", std::string(dp + p.pos, p.dashes + p.len));
         } else if (!p.dashes) {
-            res += t.format(" <fg:green>{}<t:normal>", std::string(dp + p.pos, p.len));
+            res += t.format(" <fg:green>{}<normal>", std::string(dp + p.pos, p.len));
         }
         dp += p.end();
     }
@@ -312,7 +312,7 @@ ArgParser& ArgParser::operator()(const char* argv[], bool detect_width, unsigned
     if (!parse_program_name(argv[0])) {
         // this should not occur
         auto& t = TermCtl::stderr_instance();
-        t.print("<t:bold><fg:red>Missing program name (argv[0])<t:normal>\n");
+        t.print("<bold><fg:red>Missing program name (argv[0])<normal>\n");
         exit(1);
     }
     try {
@@ -326,7 +326,7 @@ ArgParser& ArgParser::operator()(const char* argv[], bool detect_width, unsigned
         }
     } catch (const BadArgument& e) {
         auto& t = TermCtl::stderr_instance();
-        t.print("<t:bold><fg:yellow>Error: <fg:red>{}<t:normal>\n\n", e.what());
+        t.print("<bold><fg:yellow>Error: <fg:red>{}<normal>\n\n", e.what());
         print_usage();
         print_help_notice();
         exit(1);
@@ -525,7 +525,7 @@ void ArgParser::print_usage() const
 
     unsigned indent = 0;
     {
-        auto head = t.format("<t:bold><fg:yellow>Usage:<t:normal> <t:bold>{}<t:normal> ", m_progname);
+        auto head = t.format("<bold><fg:yellow>Usage:<normal> <bold>{}<normal> ", m_progname);
         indent = TermCtl::stripped_width(head);
         cout << head;
     }
@@ -545,7 +545,7 @@ void ArgParser::print_help() const
         desc_cols = std::max(desc_cols, (unsigned) opt.desc().size());
     print_usage();
     auto& t = TermCtl::stdout_instance();
-    t.print("\n<t:bold><fg:yellow>Options:<t:normal>\n");
+    t.print("\n<bold><fg:yellow>Options:<normal>\n");
     for (const auto& opt : m_opts) {
         cout << "  " << opt.formatted_desc(desc_cols) << "  ";
         wrapping_print(opt.help(), desc_cols + 4, 0, m_max_width);

--- a/src/xci/core/TermCtl.cpp
+++ b/src/xci/core/TermCtl.cpp
@@ -24,6 +24,9 @@
 #include <xci/core/file.h>
 #include <xci/config.h>
 
+#include <tao/pegtl.hpp>
+namespace pegtl = tao::pegtl;
+
 #ifdef _WIN32
     static_assert(sizeof(unsigned long) == sizeof(DWORD));
 #else
@@ -608,51 +611,60 @@ TermCtl& TermCtl::clear_line_to_end() { return TERM_APPEND(clr_eol); }
 TermCtl& TermCtl::soft_reset() { return XCI_TERM_APPEND(seq::send_soft_reset); }
 
 
+namespace format_parser {
+
+struct Char : pegtl::any {};
+struct Escape : pegtl::seq< pegtl::one<'\\'>, Char > {};
+struct Tag : pegtl::seq< pegtl::one<'<'>, pegtl::opt<pegtl::one<'@'>>, pegtl::opt<pegtl::one<'*'>>, pegtl::plus<pegtl::ranges<'a', 'z', '_'>>, pegtl::one<'>'>> {};
+struct Grammar : pegtl::must< pegtl::star<pegtl::sor<Escape, Tag, Char>>, pegtl::eof > {};
+
+template< typename Rule >
+struct Action {};
+
+template<>
+struct Action< Char > {
+    template< typename ParseInput >
+    static void apply( const ParseInput& in, TermCtl& t, std::string& r ) {
+        r.push_back(in.peek_char());
+    }
+};
+
+template<>
+struct Action< Tag > {
+    template< typename ParseInput >
+    static bool apply( const ParseInput& in, TermCtl& t, std::string& r ) {
+        auto key = in.string_view().substr(1, in.size() - 2);  // strip < >
+
+        const auto m = TermCtl::parse_mode(key);
+        if (m <= TermCtl::Mode::_Last) {
+            r += t.mode(m).seq();
+            return true;
+        }
+
+        bool is_bg = key.front() == '@';
+        if (is_bg)
+            key.remove_prefix(1);
+
+        const auto c = TermCtl::parse_color(key);
+        if (c <= TermCtl::Color::_Last) {
+            if (is_bg)
+                r += t.bg(c).seq();
+            else
+                r += t.fg(c).seq();
+            return true;
+        }
+
+        return false;
+    }
+};
+
+} // namespace format_parser
+
 std::string TermCtl::_format(std::string_view fmt)
 {
+    pegtl::memory_input in( std::to_address(fmt.begin()), std::to_address(fmt.end()) );
     std::string r;
-    r.reserve(fmt.size());
-    auto it = fmt.begin();
-    while (it != fmt.end()) {
-        if (*it == '<') {
-            ++it;
-
-            bool is_bg = false;
-            if (*it == '@') {
-                is_bg = true;
-                ++it;
-            }
-
-            auto beg = it;
-            while (std::islower(*it) || *it == '_' || *it == '*')
-                ++it;
-            std::string_view key (std::to_address(beg), it - beg);
-            if (*it == '>') {
-                const auto m = _parse_mode(key);
-                if (m <= Mode::_Last) {
-                    r += mode(m).seq();
-                    ++it;
-                    continue;
-                }
-                const auto c = _parse_color(key);
-                if (c <= Color::_Last) {
-                    if (is_bg)
-                        r += bg(c).seq();
-                    else
-                        r += fg(c).seq();
-                    ++it;
-                    continue;
-                }
-            }
-            // rollback
-            r.push_back('<');
-            if (is_bg)
-                r.push_back('@');
-            r += key;
-        }
-        r.push_back(*it);
-        ++it;
-    }
+    pegtl::parse< format_parser::Grammar, format_parser::Action >( in, *this, r );
     return r;
 }
 

--- a/src/xci/core/TermCtl.cpp
+++ b/src/xci/core/TermCtl.cpp
@@ -620,7 +620,7 @@ std::string TermCtl::_format(std::string_view fmt)
             auto beg = it;
             while (std::islower(*it) || *it == '_')
                 ++it;
-            std::string_view key (beg, it);
+            std::string_view key (std::to_address(beg), it - beg);
             if (*it == '>') {
                 const auto m = _parse_mode(key);
                 if (m <= Mode::_Last) {
@@ -639,7 +639,7 @@ std::string TermCtl::_format(std::string_view fmt)
             beg = it;
             while (std::islower(*it) || *it == '_' || *it == '*')
                 ++it;
-            std::string_view value (beg, it);
+            std::string_view value (std::to_address(beg), it-beg);
             if (*it != '>') {
                 r.push_back('<');
                 r += key;

--- a/src/xci/core/TermCtl.cpp
+++ b/src/xci/core/TermCtl.cpp
@@ -611,7 +611,7 @@ TermCtl& TermCtl::clear_line_to_end() { return TERM_APPEND(clr_eol); }
 TermCtl& TermCtl::soft_reset() { return XCI_TERM_APPEND(seq::send_soft_reset); }
 
 
-namespace format_parser {
+namespace render_parser {
 
 struct Char : pegtl::any {};
 struct Escape : pegtl::seq< pegtl::one<'\\'>, Char > {};
@@ -658,13 +658,13 @@ struct Action< Tag > {
     }
 };
 
-} // namespace format_parser
+} // namespace render_parser
 
-std::string TermCtl::_format(std::string_view fmt)
+std::string TermCtl::render(std::string_view markup)
 {
-    pegtl::memory_input in( std::to_address(fmt.begin()), std::to_address(fmt.end()) );
+    pegtl::memory_input in( std::to_address(markup.begin()), std::to_address(markup.end()) );
     std::string r;
-    pegtl::parse< format_parser::Grammar, format_parser::Action >( in, *this, r );
+    pegtl::parse< render_parser::Grammar, render_parser::Action >( in, *this, r );
     return r;
 }
 

--- a/src/xci/core/TermCtl.h
+++ b/src/xci/core/TermCtl.h
@@ -202,10 +202,11 @@ public:
     /// Format string, adding colors via special placeholders:
     /// <fg:COLOR> where COLOR is default | red | *red ... ("*" = bright)
     /// <bg:COLOR> where COLOR is the same as for fg
-    /// <t:MODE> where MODE is bold | underline | normal ...
+    /// <MODE> where MODE is bold | underline | normal ... (shortcuts b | u | n ...)
     template<typename... T>
     std::string format(fmt::format_string<T...> fmt, T&&... args) {
-        return fmt::vformat(_format({fmt.get().begin(), fmt.get().end()}),
+        const auto sv = fmt.get();
+        return fmt::vformat(_format(std::string_view(sv.data(), sv.size())),
                             fmt::make_format_args(args...));
     }
 
@@ -378,7 +379,7 @@ private:
     static constexpr Mode _parse_mode(std::string_view name) {
         Mode r = Mode::Normal;
         for (const char* n : c_mode_names) {
-            if (name == n)
+            if (name == n || (name.size() == 1 && name[0] == n[0]))
                 return r;
             r = static_cast<Mode>(uint8_t(r) + 1);
         }

--- a/src/xci/core/TermCtl.h
+++ b/src/xci/core/TermCtl.h
@@ -80,6 +80,16 @@ public:
     };
     static_assert(std::size(c_color_names) == size_t(Color::_Last) + 1);
 
+    static constexpr Color parse_color(std::string_view name) {
+        Color r = Color::Black;
+        for (const char* n : c_color_names) {
+            if (name == n)
+                return r;
+            r = static_cast<Color>(uint8_t(r) + 1);
+        }
+        return r;
+    }
+
     enum class Mode: uint8_t {
         Normal,  // reset all attributes
         Bold, Dim, Italic, Underline, Overline, CrossOut, Frame,
@@ -96,6 +106,16 @@ public:
         "no_blink", "no_reverse", "no_hidden"
     };
     static_assert(std::size(c_mode_names) == size_t(Mode::_Last) + 1);
+
+    static constexpr Mode parse_mode(std::string_view name) {
+        Mode r = Mode::Normal;
+        for (const char* n : c_mode_names) {
+            if (name == n || (name.size() == 1 && name[0] == n[0]))
+                return r;
+            r = static_cast<Mode>(uint8_t(r) + 1);
+        }
+        return r;
+    }
 
     // foreground
     TermCtl& fg(Color color);
@@ -375,26 +395,6 @@ private:
     TermCtl& _append_seq(const char* seq) { if (seq) m_seq += seq; return *this; }  // needed for TermInfo, which returns NULL for unknown seqs
     TermCtl& _append_seq(std::string_view seq) { m_seq += seq; return *this; }
     std::string _format(std::string_view fmt);
-
-    static constexpr Mode _parse_mode(std::string_view name) {
-        Mode r = Mode::Normal;
-        for (const char* n : c_mode_names) {
-            if (name == n || (name.size() == 1 && name[0] == n[0]))
-                return r;
-            r = static_cast<Mode>(uint8_t(r) + 1);
-        }
-        return r;
-    }
-
-    static constexpr Color _parse_color(std::string_view name) {
-        Color r = Color::Black;
-        for (const char* n : c_color_names) {
-            if (name == n)
-                return r;
-            r = static_cast<Color>(uint8_t(r) + 1);
-        }
-        return r;
-    }
 
     std::string m_seq;  // cached capability sequences
     WriteCallback m_write_cb;

--- a/src/xci/core/TermCtl.h
+++ b/src/xci/core/TermCtl.h
@@ -194,7 +194,7 @@ public:
     TermCtl& soft_reset();
 
     // Cached seq
-    std::string seq() { return std::move(m_seq); }
+    std::string seq() { auto s = std::move(m_seq); m_seq.clear(); return s; }
     void write() { write_raw(seq()); }
     void write_nl() { m_seq.append(1, '\n'); write(seq()); }
     friend std::ostream& operator<<(std::ostream& os, TermCtl& t) { return os << t.seq(); }

--- a/src/xci/core/TermCtl.h
+++ b/src/xci/core/TermCtl.h
@@ -200,8 +200,8 @@ public:
     friend std::ostream& operator<<(std::ostream& os, TermCtl& t) { return os << t.seq(); }
 
     /// Format string, adding colors via special placeholders:
-    /// <fg:COLOR> where COLOR is default | red | *red ... ("*" = bright)
-    /// <bg:COLOR> where COLOR is the same as for fg
+    /// <COLOR> where COLOR is default | red | *red ... ("*" = bright)
+    /// <@BG_COLOR> where BG_COLOR is the same as for COLOR
     /// <MODE> where MODE is bold | underline | normal ... (shortcuts b | u | n ...)
     template<typename... T>
     std::string format(fmt::format_string<T...> fmt, T&&... args) {

--- a/src/xci/core/log_termctl.cpp
+++ b/src/xci/core/log_termctl.cpp
@@ -19,18 +19,18 @@ namespace xci::core {
 // 5..9 => multi-line continuation for each log level
 static constexpr size_t c_cont = 5;
 static constexpr const char* c_log_format[] = {
-        "{0:%F %T} <fg:cyan>{1:6x}<t:normal>  <t:bold>TRACE<t:normal>  <fg:blue>{2}<t:normal>\n",
-        "{0:%F %T} <fg:cyan>{1:6x}<t:normal>  <t:bold>DEBUG<t:normal>  <fg:white>{2}<t:normal>\n",
-        "{0:%F %T} <fg:cyan>{1:6x}<t:normal>  <t:bold>INFO <t:normal>  <t:bold><fg:white>{2}<t:normal>\n",
-        "{0:%F %T} <fg:cyan>{1:6x}<t:normal>  <t:bold>WARN <t:normal>  <t:bold><fg:yellow>{2}<t:normal>\n",
-        "{0:%F %T} <fg:cyan>{1:6x}<t:normal>  <t:bold>ERROR<t:normal>  <t:bold><fg:red>{2}<t:normal>\n",
-        "                            <t:bold>...<t:normal>    <fg:blue>{2}<t:normal>\n",
-        "                            <t:bold>...<t:normal>    <fg:white>{2}<t:normal>\n",
-        "                            <t:bold>...<t:normal>    <t:bold><fg:white>{2}<t:normal>\n",
-        "                            <t:bold>...<t:normal>    <t:bold><fg:yellow>{2}<t:normal>\n",
-        "                            <t:bold>...<t:normal>    <t:bold><fg:red>{2}<t:normal>\n",
+        "{0:%F %T} <fg:cyan>{1:6x}<normal>  <bold>TRACE<normal>  <fg:blue>{2}<normal>\n",
+        "{0:%F %T} <fg:cyan>{1:6x}<normal>  <bold>DEBUG<normal>  <fg:white>{2}<normal>\n",
+        "{0:%F %T} <fg:cyan>{1:6x}<normal>  <bold>INFO <normal>  <bold><fg:white>{2}<normal>\n",
+        "{0:%F %T} <fg:cyan>{1:6x}<normal>  <bold>WARN <normal>  <bold><fg:yellow>{2}<normal>\n",
+        "{0:%F %T} <fg:cyan>{1:6x}<normal>  <bold>ERROR<normal>  <bold><fg:red>{2}<normal>\n",
+        "                            <bold>...<normal>    <fg:blue>{2}<normal>\n",
+        "                            <bold>...<normal>    <fg:white>{2}<normal>\n",
+        "                            <bold>...<normal>    <bold><fg:white>{2}<normal>\n",
+        "                            <bold>...<normal>    <bold><fg:yellow>{2}<normal>\n",
+        "                            <bold>...<normal>    <bold><fg:red>{2}<normal>\n",
 };
-static constexpr const char* c_log_intro = "<t:underline>   Date      Time    TID    Level  Message   <t:normal>\n";
+static constexpr const char* c_log_intro = "<underline>   Date      Time    TID    Level  Message   <normal>\n";
 
 
 Logger::Logger(Level level) : m_level(level)

--- a/src/xci/core/log_termctl.cpp
+++ b/src/xci/core/log_termctl.cpp
@@ -19,18 +19,18 @@ namespace xci::core {
 // 5..9 => multi-line continuation for each log level
 static constexpr size_t c_cont = 5;
 static constexpr const char* c_log_format[] = {
-        "{0:%F %T} {fg:cyan}{1:6x}{t:normal}  {t:bold}TRACE{t:normal}  {fg:blue}{2}{t:normal}\n",
-        "{0:%F %T} {fg:cyan}{1:6x}{t:normal}  {t:bold}DEBUG{t:normal}  {fg:white}{2}{t:normal}\n",
-        "{0:%F %T} {fg:cyan}{1:6x}{t:normal}  {t:bold}INFO {t:normal}  {t:bold}{fg:white}{2}{t:normal}\n",
-        "{0:%F %T} {fg:cyan}{1:6x}{t:normal}  {t:bold}WARN {t:normal}  {t:bold}{fg:yellow}{2}{t:normal}\n",
-        "{0:%F %T} {fg:cyan}{1:6x}{t:normal}  {t:bold}ERROR{t:normal}  {t:bold}{fg:red}{2}{t:normal}\n",
-        "                            {t:bold}...{t:normal}    {fg:blue}{2}{t:normal}\n",
-        "                            {t:bold}...{t:normal}    {fg:white}{2}{t:normal}\n",
-        "                            {t:bold}...{t:normal}    {t:bold}{fg:white}{2}{t:normal}\n",
-        "                            {t:bold}...{t:normal}    {t:bold}{fg:yellow}{2}{t:normal}\n",
-        "                            {t:bold}...{t:normal}    {t:bold}{fg:red}{2}{t:normal}\n",
+        "{0:%F %T} <fg:cyan>{1:6x}<t:normal>  <t:bold>TRACE<t:normal>  <fg:blue>{2}<t:normal>\n",
+        "{0:%F %T} <fg:cyan>{1:6x}<t:normal>  <t:bold>DEBUG<t:normal>  <fg:white>{2}<t:normal>\n",
+        "{0:%F %T} <fg:cyan>{1:6x}<t:normal>  <t:bold>INFO <t:normal>  <t:bold><fg:white>{2}<t:normal>\n",
+        "{0:%F %T} <fg:cyan>{1:6x}<t:normal>  <t:bold>WARN <t:normal>  <t:bold><fg:yellow>{2}<t:normal>\n",
+        "{0:%F %T} <fg:cyan>{1:6x}<t:normal>  <t:bold>ERROR<t:normal>  <t:bold><fg:red>{2}<t:normal>\n",
+        "                            <t:bold>...<t:normal>    <fg:blue>{2}<t:normal>\n",
+        "                            <t:bold>...<t:normal>    <fg:white>{2}<t:normal>\n",
+        "                            <t:bold>...<t:normal>    <t:bold><fg:white>{2}<t:normal>\n",
+        "                            <t:bold>...<t:normal>    <t:bold><fg:yellow>{2}<t:normal>\n",
+        "                            <t:bold>...<t:normal>    <t:bold><fg:red>{2}<t:normal>\n",
 };
-static constexpr const char* c_log_intro = "{t:underline}   Date      Time    TID    Level  Message   {t:normal}\n";
+static constexpr const char* c_log_intro = "<t:underline>   Date      Time    TID    Level  Message   <t:normal>\n";
 
 
 Logger::Logger(Level level) : m_level(level)

--- a/src/xci/core/log_termctl.cpp
+++ b/src/xci/core/log_termctl.cpp
@@ -19,16 +19,16 @@ namespace xci::core {
 // 5..9 => multi-line continuation for each log level
 static constexpr size_t c_cont = 5;
 static constexpr const char* c_log_format[] = {
-        "{0:%F %T} <fg:cyan>{1:6x}<normal>  <bold>TRACE<normal>  <fg:blue>{2}<normal>\n",
-        "{0:%F %T} <fg:cyan>{1:6x}<normal>  <bold>DEBUG<normal>  <fg:white>{2}<normal>\n",
-        "{0:%F %T} <fg:cyan>{1:6x}<normal>  <bold>INFO <normal>  <bold><fg:white>{2}<normal>\n",
-        "{0:%F %T} <fg:cyan>{1:6x}<normal>  <bold>WARN <normal>  <bold><fg:yellow>{2}<normal>\n",
-        "{0:%F %T} <fg:cyan>{1:6x}<normal>  <bold>ERROR<normal>  <bold><fg:red>{2}<normal>\n",
-        "                            <bold>...<normal>    <fg:blue>{2}<normal>\n",
-        "                            <bold>...<normal>    <fg:white>{2}<normal>\n",
-        "                            <bold>...<normal>    <bold><fg:white>{2}<normal>\n",
-        "                            <bold>...<normal>    <bold><fg:yellow>{2}<normal>\n",
-        "                            <bold>...<normal>    <bold><fg:red>{2}<normal>\n",
+        "{0:%F %T} <cyan>{1:6x}<normal>  <bold>TRACE<normal>  <blue>{2}<normal>\n",
+        "{0:%F %T} <cyan>{1:6x}<normal>  <bold>DEBUG<normal>  <white>{2}<normal>\n",
+        "{0:%F %T} <cyan>{1:6x}<normal>  <bold>INFO <normal>  <bold><white>{2}<normal>\n",
+        "{0:%F %T} <cyan>{1:6x}<normal>  <bold>WARN <normal>  <bold><yellow>{2}<normal>\n",
+        "{0:%F %T} <cyan>{1:6x}<normal>  <bold>ERROR<normal>  <bold><red>{2}<normal>\n",
+        "                            <bold>...<normal>    <blue>{2}<normal>\n",
+        "                            <bold>...<normal>    <white>{2}<normal>\n",
+        "                            <bold>...<normal>    <bold><white>{2}<normal>\n",
+        "                            <bold>...<normal>    <bold><yellow>{2}<normal>\n",
+        "                            <bold>...<normal>    <bold><red>{2}<normal>\n",
 };
 static constexpr const char* c_log_intro = "<underline>   Date      Time    TID    Level  Message   <normal>\n";
 

--- a/tests/test_core.cpp
+++ b/tests/test_core.cpp
@@ -297,7 +297,7 @@ TEST_CASE( "stripped_width", "[TermCtl]" )
     CHECK(TermCtl::stripped_width("test") == 4);
     CHECK(TermCtl::stripped_width("❓") == 2);
     TermCtl t(1, TermCtl::IsTty::Always);
-    CHECK(TermCtl::stripped_width(t.format("<fg:green>test<t:normal>")) == 4);
+    CHECK(TermCtl::stripped_width(t.format("<fg:green>test<normal>")) == 4);
     CHECK(TermCtl::stripped_width("\x1b[32mtest\x1b(B\x1b[m") == 4);
     CHECK(TermCtl::stripped_width("\n") == 1);  // newline is 1 column (special handling in EditLine)
 }

--- a/tests/test_core.cpp
+++ b/tests/test_core.cpp
@@ -297,7 +297,7 @@ TEST_CASE( "stripped_width", "[TermCtl]" )
     CHECK(TermCtl::stripped_width("test") == 4);
     CHECK(TermCtl::stripped_width("❓") == 2);
     TermCtl t(1, TermCtl::IsTty::Always);
-    CHECK(TermCtl::stripped_width(t.format("<fg:green>test<normal>")) == 4);
+    CHECK(TermCtl::stripped_width(t.format("<green>test<normal>")) == 4);
     CHECK(TermCtl::stripped_width("\x1b[32mtest\x1b(B\x1b[m") == 4);
     CHECK(TermCtl::stripped_width("\n") == 1);  // newline is 1 column (special handling in EditLine)
 }

--- a/tests/test_core.cpp
+++ b/tests/test_core.cpp
@@ -297,7 +297,7 @@ TEST_CASE( "stripped_width", "[TermCtl]" )
     CHECK(TermCtl::stripped_width("test") == 4);
     CHECK(TermCtl::stripped_width("❓") == 2);
     TermCtl t(1, TermCtl::IsTty::Always);
-    CHECK(TermCtl::stripped_width(t.format("{fg:green}test{t:normal}")) == 4);
+    CHECK(TermCtl::stripped_width(t.format("<fg:green>test<t:normal>")) == 4);
     CHECK(TermCtl::stripped_width("\x1b[32mtest\x1b(B\x1b[m") == 4);
     CHECK(TermCtl::stripped_width("\n") == 1);  // newline is 1 column (special handling in EditLine)
 }

--- a/tools/data_archive/dar.cpp
+++ b/tools/data_archive/dar.cpp
@@ -28,7 +28,7 @@ static void extract_entry(const std::string& name, const VfsFile& file, const fs
 {
     const auto entry_path = output_path / name;
     TermCtl& term = TermCtl::stdout_instance();
-    term.print("Extracting file\t<fg:yellow>{}<normal> to {}\n", name, entry_path);
+    term.print("Extracting file\t<yellow>{}<normal> to {}\n", name, entry_path);
     auto content = file.content();
     if (content) {
         fs::create_directories(entry_path.parent_path());
@@ -152,20 +152,20 @@ int main(int argc, const char* argv[])
     } (argv);
 
     if (files.empty()) {
-        term.print("<bold><fg:yellow>No input files.<normal>\n");
+        term.print("<bold><yellow>No input files.<normal>\n");
     }
 
     Vfs vfs;
     for (const auto filename : files) {
-        term.print("<bold>Extracting archive\t<fg:yellow>{}<normal>\n", filename);
+        term.print("<bold>Extracting archive\t<yellow>{}<normal>\n", filename);
         if (!vfs.mount(filename)) {
-            term.print("<bold><fg:red>Could not mount {}<normal>\n", filename);
+            term.print("<bold><red>Could not mount {}<normal>\n", filename);
             continue;
         }
 
         if (list_entries) {
             for (const auto& entry : *vfs.mounts().back().vfs_dir) {
-                term.print("<fg:yellow>{}<normal>\n", entry.name());
+                term.print("<yellow>{}<normal>\n", entry.name());
             }
             continue;
         }

--- a/tools/data_archive/dar.cpp
+++ b/tools/data_archive/dar.cpp
@@ -28,7 +28,7 @@ static void extract_entry(const std::string& name, const VfsFile& file, const fs
 {
     const auto entry_path = output_path / name;
     TermCtl& term = TermCtl::stdout_instance();
-    term.print("Extracting file\t<fg:yellow>{}<t:normal> to {}\n", name, entry_path);
+    term.print("Extracting file\t<fg:yellow>{}<normal> to {}\n", name, entry_path);
     auto content = file.content();
     if (content) {
         fs::create_directories(entry_path.parent_path());
@@ -152,20 +152,20 @@ int main(int argc, const char* argv[])
     } (argv);
 
     if (files.empty()) {
-        term.print("<t:bold><fg:yellow>No input files.<t:normal>\n");
+        term.print("<bold><fg:yellow>No input files.<normal>\n");
     }
 
     Vfs vfs;
     for (const auto filename : files) {
-        term.print("<t:bold>Extracting archive\t<fg:yellow>{}<t:normal>\n", filename);
+        term.print("<bold>Extracting archive\t<fg:yellow>{}<normal>\n", filename);
         if (!vfs.mount(filename)) {
-            term.print("<t:bold><fg:red>Could not mount {}<t:normal>\n", filename);
+            term.print("<bold><fg:red>Could not mount {}<normal>\n", filename);
             continue;
         }
 
         if (list_entries) {
             for (const auto& entry : *vfs.mounts().back().vfs_dir) {
-                term.print("<fg:yellow>{}<t:normal>\n", entry.name());
+                term.print("<fg:yellow>{}<normal>\n", entry.name());
             }
             continue;
         }

--- a/tools/data_archive/dar.cpp
+++ b/tools/data_archive/dar.cpp
@@ -28,7 +28,7 @@ static void extract_entry(const std::string& name, const VfsFile& file, const fs
 {
     const auto entry_path = output_path / name;
     TermCtl& term = TermCtl::stdout_instance();
-    term.print("Extracting file\t{fg:yellow}{}{t:normal} to {}\n", name, entry_path);
+    term.print("Extracting file\t<fg:yellow>{}<t:normal> to {}\n", name, entry_path);
     auto content = file.content();
     if (content) {
         fs::create_directories(entry_path.parent_path());
@@ -152,20 +152,20 @@ int main(int argc, const char* argv[])
     } (argv);
 
     if (files.empty()) {
-        term.print("{t:bold}{fg:yellow}No input files.{t:normal}\n");
+        term.print("<t:bold><fg:yellow>No input files.<t:normal>\n");
     }
 
     Vfs vfs;
     for (const auto filename : files) {
-        term.print("{t:bold}Extracting archive\t{fg:yellow}{}{t:normal}\n", filename);
+        term.print("<t:bold>Extracting archive\t<fg:yellow>{}<t:normal>\n", filename);
         if (!vfs.mount(filename)) {
-            term.print("{t:bold}{fg:red}Could not mount {}{t:normal}\n", filename);
+            term.print("<t:bold><fg:red>Could not mount {}<t:normal>\n", filename);
             continue;
         }
 
         if (list_entries) {
             for (const auto& entry : *vfs.mounts().back().vfs_dir) {
-                term.print("{fg:yellow}{}{t:normal}\n", entry.name());
+                term.print("<fg:yellow>{}<t:normal>\n", entry.name());
             }
             continue;
         }

--- a/tools/data_inspect/dati.cpp
+++ b/tools/data_inspect/dati.cpp
@@ -54,33 +54,33 @@ static void print_data(TermCtl& term, uint8_t type, const std::byte* data, size_
 {
     const auto expected_size = BinaryBase::size_by_type(type);
     if (expected_size != size_t(-1) && size != expected_size) {
-        term.print("<fg:red>bad size {}<normal>", size);
+        term.print("<red>bad size {}<normal>", size);
         return;
     }
 
     switch (type) {
-        case BinaryBase::Null:      term.print("<fg:yellow>null<normal>"); return;
-        case BinaryBase::BoolFalse: term.print("<fg:yellow>false<normal>"); return;
-        case BinaryBase::BoolTrue:  term.print("<fg:yellow>true<normal>"); return;
-        case BinaryBase::Fixed8:    term.print("<fg:magenta>{}<normal>", unsigned(*data)); return;
-        case BinaryBase::Fixed16:   term.print("<fg:magenta>{}<normal>", bit_copy<uint16_t>(data)); return;
-        case BinaryBase::Fixed32:   term.print("<fg:magenta>{}<normal>", bit_copy<uint32_t>(data)); return;
-        case BinaryBase::Fixed64:   term.print("<fg:magenta>{}<normal>", bit_copy<uint64_t>(data)); return;
-        case BinaryBase::Fixed128:  term.print("<fg:magenta>{}<normal>", uint128_to_string(bit_copy<uint128>(data))); return;
-        case BinaryBase::Float32:   term.print("<fg:magenta>{}<normal>", bit_copy<float>(data)); return;
-        case BinaryBase::Float64:   term.print("<fg:magenta>{}<normal>", bit_copy<double>(data)); return;
-        case BinaryBase::VarInt:    term.print("<fg:yellow>varint<normal>"); return;
-        case BinaryBase::Array:     term.print("<fg:yellow>array<normal>"); return;
+        case BinaryBase::Null:      term.print("<yellow>null<normal>"); return;
+        case BinaryBase::BoolFalse: term.print("<yellow>false<normal>"); return;
+        case BinaryBase::BoolTrue:  term.print("<yellow>true<normal>"); return;
+        case BinaryBase::Fixed8:    term.print("<magenta>{}<normal>", unsigned(*data)); return;
+        case BinaryBase::Fixed16:   term.print("<magenta>{}<normal>", bit_copy<uint16_t>(data)); return;
+        case BinaryBase::Fixed32:   term.print("<magenta>{}<normal>", bit_copy<uint32_t>(data)); return;
+        case BinaryBase::Fixed64:   term.print("<magenta>{}<normal>", bit_copy<uint64_t>(data)); return;
+        case BinaryBase::Fixed128:  term.print("<magenta>{}<normal>", uint128_to_string(bit_copy<uint128>(data))); return;
+        case BinaryBase::Float32:   term.print("<magenta>{}<normal>", bit_copy<float>(data)); return;
+        case BinaryBase::Float64:   term.print("<magenta>{}<normal>", bit_copy<double>(data)); return;
+        case BinaryBase::VarInt:    term.print("<yellow>varint<normal>"); return;
+        case BinaryBase::Array:     term.print("<yellow>array<normal>"); return;
         case BinaryBase::String:
-            term.print("<fg:green>\"{}\"<normal>",
+            term.print("<green>\"{}\"<normal>",
                     escape(std::string_view((const char*) data, size)));
             return;
-        case BinaryBase::Binary:    term.print("<fg:yellow>(size {})<normal>", size); return;
+        case BinaryBase::Binary:    term.print("<yellow>(size {})<normal>", size); return;
         case BinaryBase::Master:
-            term.print("<fg:yellow>(size {})<normal> <bold>{{<normal>", size); return;
-        case BinaryBase::Control:   term.print("<fg:yellow>control<normal>"); return;
+            term.print("<yellow>(size {})<normal> <bold>{{<normal>", size); return;
+        case BinaryBase::Control:   term.print("<yellow>control<normal>"); return;
     }
-    term.print("<fg:red>unknown<normal>");
+    term.print("<red>unknown<normal>");
 }
 
 
@@ -110,7 +110,7 @@ int main(int argc, const char* argv[])
     } (argv);
 
     if (files.empty()) {
-        term.print("<bold><fg:yellow>No input files.<normal>\n");
+        term.print("<bold><yellow>No input files.<normal>\n");
     }
 
     Schema schema;
@@ -121,7 +121,7 @@ int main(int argc, const char* argv[])
             reader(schema);
             reader.finish_and_check();
         } catch (const ArchiveError& e) {
-            term.print("<bold><fg:red>Error reading schema: {}<normal>\n", e.what());
+            term.print("<bold><red>Error reading schema: {}<normal>\n", e.what());
         }
     } else if (files.size() == 1 && std::string(files.back()).ends_with(".schema")) {
         // get Schema of .schema file
@@ -129,7 +129,7 @@ int main(int argc, const char* argv[])
     }
 
     for (const auto& filename : files) {
-        term.print("<fg:yellow><bold>{}<normal>\n", filename);
+        term.print("<yellow><bold>{}<normal>\n", filename);
         std::ifstream f(filename, std::ios::binary);
         try {
             BinaryReader reader(f);
@@ -182,12 +182,12 @@ int main(int argc, const char* argv[])
                                     if (opt_int)
                                         last_int_values[schema_member->name] = *opt_int;
                                 }
-                                term.print("{}<bold><fg:cyan>{} ({}: {})<normal>: {} = ",
+                                term.print("{}<bold><cyan>{} ({}: {})<normal>: {} = ",
                                            std::string(indent, ' '),
                                            int(it.key), schema_member->name, schema_member->type,
                                            type_to_cstr(it.type));
                             } else {
-                                term.print("{}<bold><fg:cyan>{}<normal>: {} = ",
+                                term.print("{}<bold><cyan>{}<normal>: {} = ",
                                            std::string(indent, ' '),
                                            int(it.key), type_to_cstr(it.type));
                             }
@@ -198,9 +198,9 @@ int main(int argc, const char* argv[])
                                 uint32_t stored_crc = 0;
                                 std::memcpy(&stored_crc, it.data.get(), it.size);
                                 if (reader.crc() == stored_crc)
-                                    term.print(" <bold><fg:green>(CRC32: OK)<normal>");
+                                    term.print(" <bold><green>(CRC32: OK)<normal>");
                                 else
-                                    term.print(" <bold><fg:red>(CRC32: expected {})<normal>",
+                                    term.print(" <bold><red>(CRC32: expected {})<normal>",
                                             reader.crc());
                             }
                         }
@@ -228,7 +228,7 @@ int main(int argc, const char* argv[])
                 }
             }
         } catch (const ArchiveError& e) {
-            term.print("<bold><fg:red>{}<normal>\n", e.what());
+            term.print("<bold><red>{}<normal>\n", e.what());
         }
     }
 

--- a/tools/data_inspect/dati.cpp
+++ b/tools/data_inspect/dati.cpp
@@ -1,7 +1,7 @@
 // data_inspect.cpp created on 2020-08-15 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2020–2023 Radek Brich
+// Copyright 2020–2024 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 /// Data Inspector (dati) command line tool
@@ -54,33 +54,33 @@ static void print_data(TermCtl& term, uint8_t type, const std::byte* data, size_
 {
     const auto expected_size = BinaryBase::size_by_type(type);
     if (expected_size != size_t(-1) && size != expected_size) {
-        term.print("{fg:red}bad size {}{t:normal}", size);
+        term.print("<fg:red>bad size {}<t:normal>", size);
         return;
     }
 
     switch (type) {
-        case BinaryBase::Null:      term.print("{fg:yellow}null{t:normal}"); return;
-        case BinaryBase::BoolFalse: term.print("{fg:yellow}false{t:normal}"); return;
-        case BinaryBase::BoolTrue:  term.print("{fg:yellow}true{t:normal}"); return;
-        case BinaryBase::Fixed8:    term.print("{fg:magenta}{}{t:normal}", unsigned(*data)); return;
-        case BinaryBase::Fixed16:   term.print("{fg:magenta}{}{t:normal}", bit_copy<uint16_t>(data)); return;
-        case BinaryBase::Fixed32:   term.print("{fg:magenta}{}{t:normal}", bit_copy<uint32_t>(data)); return;
-        case BinaryBase::Fixed64:   term.print("{fg:magenta}{}{t:normal}", bit_copy<uint64_t>(data)); return;
-        case BinaryBase::Fixed128:  term.print("{fg:magenta}{}{t:normal}", uint128_to_string(bit_copy<uint128>(data))); return;
-        case BinaryBase::Float32:   term.print("{fg:magenta}{}{t:normal}", bit_copy<float>(data)); return;
-        case BinaryBase::Float64:   term.print("{fg:magenta}{}{t:normal}", bit_copy<double>(data)); return;
-        case BinaryBase::VarInt:    term.print("{fg:yellow}varint{t:normal}"); return;
-        case BinaryBase::Array:     term.print("{fg:yellow}array{t:normal}"); return;
+        case BinaryBase::Null:      term.print("<fg:yellow>null<t:normal>"); return;
+        case BinaryBase::BoolFalse: term.print("<fg:yellow>false<t:normal>"); return;
+        case BinaryBase::BoolTrue:  term.print("<fg:yellow>true<t:normal>"); return;
+        case BinaryBase::Fixed8:    term.print("<fg:magenta>{}<t:normal>", unsigned(*data)); return;
+        case BinaryBase::Fixed16:   term.print("<fg:magenta>{}<t:normal>", bit_copy<uint16_t>(data)); return;
+        case BinaryBase::Fixed32:   term.print("<fg:magenta>{}<t:normal>", bit_copy<uint32_t>(data)); return;
+        case BinaryBase::Fixed64:   term.print("<fg:magenta>{}<t:normal>", bit_copy<uint64_t>(data)); return;
+        case BinaryBase::Fixed128:  term.print("<fg:magenta>{}<t:normal>", uint128_to_string(bit_copy<uint128>(data))); return;
+        case BinaryBase::Float32:   term.print("<fg:magenta>{}<t:normal>", bit_copy<float>(data)); return;
+        case BinaryBase::Float64:   term.print("<fg:magenta>{}<t:normal>", bit_copy<double>(data)); return;
+        case BinaryBase::VarInt:    term.print("<fg:yellow>varint<t:normal>"); return;
+        case BinaryBase::Array:     term.print("<fg:yellow>array<t:normal>"); return;
         case BinaryBase::String:
-            term.print("{fg:green}\"{}\"{t:normal}",
+            term.print("<fg:green>\"{}\"<t:normal>",
                     escape(std::string_view((const char*) data, size)));
             return;
-        case BinaryBase::Binary:    term.print("{fg:yellow}(size {}){t:normal}", size); return;
+        case BinaryBase::Binary:    term.print("<fg:yellow>(size {})<t:normal>", size); return;
         case BinaryBase::Master:
-            term.print("{fg:yellow}(size {}){t:normal} {t:bold}{{{t:normal}", size); return;
-        case BinaryBase::Control:   term.print("{fg:yellow}control{t:normal}"); return;
+            term.print("<fg:yellow>(size {})<t:normal> <t:bold>{{<t:normal>", size); return;
+        case BinaryBase::Control:   term.print("<fg:yellow>control<t:normal>"); return;
     }
-    term.print("{fg:red}unknown{t:normal}");
+    term.print("<fg:red>unknown<t:normal>");
 }
 
 
@@ -110,7 +110,7 @@ int main(int argc, const char* argv[])
     } (argv);
 
     if (files.empty()) {
-        term.print("{t:bold}{fg:yellow}No input files.{t:normal}\n");
+        term.print("<t:bold><fg:yellow>No input files.<t:normal>\n");
     }
 
     Schema schema;
@@ -121,7 +121,7 @@ int main(int argc, const char* argv[])
             reader(schema);
             reader.finish_and_check();
         } catch (const ArchiveError& e) {
-            term.print("{t:bold}{fg:red}Error reading schema: {}{t:normal}\n", e.what());
+            term.print("<t:bold><fg:red>Error reading schema: {}<t:normal>\n", e.what());
         }
     } else if (files.size() == 1 && std::string(files.back()).ends_with(".schema")) {
         // get Schema of .schema file
@@ -129,7 +129,7 @@ int main(int argc, const char* argv[])
     }
 
     for (const auto& filename : files) {
-        term.print("{fg:yellow}{t:bold}{}{t:normal}\n", filename);
+        term.print("<fg:yellow><t:bold>{}<t:normal>\n", filename);
         std::ifstream f(filename, std::ios::binary);
         try {
             BinaryReader reader(f);
@@ -182,12 +182,12 @@ int main(int argc, const char* argv[])
                                     if (opt_int)
                                         last_int_values[schema_member->name] = *opt_int;
                                 }
-                                term.print("{}{t:bold}{fg:cyan}{} ({}: {}){t:normal}: {} = ",
+                                term.print("{}<t:bold><fg:cyan>{} ({}: {})<t:normal>: {} = ",
                                            std::string(indent, ' '),
                                            int(it.key), schema_member->name, schema_member->type,
                                            type_to_cstr(it.type));
                             } else {
-                                term.print("{}{t:bold}{fg:cyan}{}{t:normal}: {} = ",
+                                term.print("{}<t:bold><fg:cyan>{}<t:normal>: {} = ",
                                            std::string(indent, ' '),
                                            int(it.key), type_to_cstr(it.type));
                             }
@@ -198,9 +198,9 @@ int main(int argc, const char* argv[])
                                 uint32_t stored_crc = 0;
                                 std::memcpy(&stored_crc, it.data.get(), it.size);
                                 if (reader.crc() == stored_crc)
-                                    term.print(" {t:bold}{fg:green}(CRC32: OK){t:normal}");
+                                    term.print(" <t:bold><fg:green>(CRC32: OK)<t:normal>");
                                 else
-                                    term.print(" {t:bold}{fg:red}(CRC32: expected {}){t:normal}",
+                                    term.print(" <t:bold><fg:red>(CRC32: expected {})<t:normal>",
                                             reader.crc());
                             }
                         }
@@ -214,13 +214,13 @@ int main(int argc, const char* argv[])
                     case What::LeaveGroup:
                         struct_stack.pop_back();
                         last_int_values.clear();
-                        term.print("{t:bold}{}}}{t:normal}\n", std::string(indent - 4, ' '));
+                        term.print("<t:bold>{}}}<t:normal>\n", std::string(indent - 4, ' '));
                         break;
                     case What::EnterMetadata:
-                        term.print("{t:bold}{}Metadata:{t:normal}\n", std::string(indent, ' '));
+                        term.print("<t:bold>{}Metadata:<t:normal>\n", std::string(indent, ' '));
                         break;
                     case What::LeaveMetadata:
-                        term.print("{t:bold}{}Data:{t:normal}\n", std::string(indent, ' '));
+                        term.print("<t:bold>{}Data:<t:normal>\n", std::string(indent, ' '));
                         break;
                     case What::EndOfFile:
                         eof = true;
@@ -228,7 +228,7 @@ int main(int argc, const char* argv[])
                 }
             }
         } catch (const ArchiveError& e) {
-            term.print("{t:bold}{fg:red}{}{t:normal}\n", e.what());
+            term.print("<t:bold><fg:red>{}<t:normal>\n", e.what());
         }
     }
 

--- a/tools/data_inspect/dati.cpp
+++ b/tools/data_inspect/dati.cpp
@@ -54,33 +54,33 @@ static void print_data(TermCtl& term, uint8_t type, const std::byte* data, size_
 {
     const auto expected_size = BinaryBase::size_by_type(type);
     if (expected_size != size_t(-1) && size != expected_size) {
-        term.print("<fg:red>bad size {}<t:normal>", size);
+        term.print("<fg:red>bad size {}<normal>", size);
         return;
     }
 
     switch (type) {
-        case BinaryBase::Null:      term.print("<fg:yellow>null<t:normal>"); return;
-        case BinaryBase::BoolFalse: term.print("<fg:yellow>false<t:normal>"); return;
-        case BinaryBase::BoolTrue:  term.print("<fg:yellow>true<t:normal>"); return;
-        case BinaryBase::Fixed8:    term.print("<fg:magenta>{}<t:normal>", unsigned(*data)); return;
-        case BinaryBase::Fixed16:   term.print("<fg:magenta>{}<t:normal>", bit_copy<uint16_t>(data)); return;
-        case BinaryBase::Fixed32:   term.print("<fg:magenta>{}<t:normal>", bit_copy<uint32_t>(data)); return;
-        case BinaryBase::Fixed64:   term.print("<fg:magenta>{}<t:normal>", bit_copy<uint64_t>(data)); return;
-        case BinaryBase::Fixed128:  term.print("<fg:magenta>{}<t:normal>", uint128_to_string(bit_copy<uint128>(data))); return;
-        case BinaryBase::Float32:   term.print("<fg:magenta>{}<t:normal>", bit_copy<float>(data)); return;
-        case BinaryBase::Float64:   term.print("<fg:magenta>{}<t:normal>", bit_copy<double>(data)); return;
-        case BinaryBase::VarInt:    term.print("<fg:yellow>varint<t:normal>"); return;
-        case BinaryBase::Array:     term.print("<fg:yellow>array<t:normal>"); return;
+        case BinaryBase::Null:      term.print("<fg:yellow>null<normal>"); return;
+        case BinaryBase::BoolFalse: term.print("<fg:yellow>false<normal>"); return;
+        case BinaryBase::BoolTrue:  term.print("<fg:yellow>true<normal>"); return;
+        case BinaryBase::Fixed8:    term.print("<fg:magenta>{}<normal>", unsigned(*data)); return;
+        case BinaryBase::Fixed16:   term.print("<fg:magenta>{}<normal>", bit_copy<uint16_t>(data)); return;
+        case BinaryBase::Fixed32:   term.print("<fg:magenta>{}<normal>", bit_copy<uint32_t>(data)); return;
+        case BinaryBase::Fixed64:   term.print("<fg:magenta>{}<normal>", bit_copy<uint64_t>(data)); return;
+        case BinaryBase::Fixed128:  term.print("<fg:magenta>{}<normal>", uint128_to_string(bit_copy<uint128>(data))); return;
+        case BinaryBase::Float32:   term.print("<fg:magenta>{}<normal>", bit_copy<float>(data)); return;
+        case BinaryBase::Float64:   term.print("<fg:magenta>{}<normal>", bit_copy<double>(data)); return;
+        case BinaryBase::VarInt:    term.print("<fg:yellow>varint<normal>"); return;
+        case BinaryBase::Array:     term.print("<fg:yellow>array<normal>"); return;
         case BinaryBase::String:
-            term.print("<fg:green>\"{}\"<t:normal>",
+            term.print("<fg:green>\"{}\"<normal>",
                     escape(std::string_view((const char*) data, size)));
             return;
-        case BinaryBase::Binary:    term.print("<fg:yellow>(size {})<t:normal>", size); return;
+        case BinaryBase::Binary:    term.print("<fg:yellow>(size {})<normal>", size); return;
         case BinaryBase::Master:
-            term.print("<fg:yellow>(size {})<t:normal> <t:bold>{{<t:normal>", size); return;
-        case BinaryBase::Control:   term.print("<fg:yellow>control<t:normal>"); return;
+            term.print("<fg:yellow>(size {})<normal> <bold>{{<normal>", size); return;
+        case BinaryBase::Control:   term.print("<fg:yellow>control<normal>"); return;
     }
-    term.print("<fg:red>unknown<t:normal>");
+    term.print("<fg:red>unknown<normal>");
 }
 
 
@@ -110,7 +110,7 @@ int main(int argc, const char* argv[])
     } (argv);
 
     if (files.empty()) {
-        term.print("<t:bold><fg:yellow>No input files.<t:normal>\n");
+        term.print("<bold><fg:yellow>No input files.<normal>\n");
     }
 
     Schema schema;
@@ -121,7 +121,7 @@ int main(int argc, const char* argv[])
             reader(schema);
             reader.finish_and_check();
         } catch (const ArchiveError& e) {
-            term.print("<t:bold><fg:red>Error reading schema: {}<t:normal>\n", e.what());
+            term.print("<bold><fg:red>Error reading schema: {}<normal>\n", e.what());
         }
     } else if (files.size() == 1 && std::string(files.back()).ends_with(".schema")) {
         // get Schema of .schema file
@@ -129,7 +129,7 @@ int main(int argc, const char* argv[])
     }
 
     for (const auto& filename : files) {
-        term.print("<fg:yellow><t:bold>{}<t:normal>\n", filename);
+        term.print("<fg:yellow><bold>{}<normal>\n", filename);
         std::ifstream f(filename, std::ios::binary);
         try {
             BinaryReader reader(f);
@@ -182,12 +182,12 @@ int main(int argc, const char* argv[])
                                     if (opt_int)
                                         last_int_values[schema_member->name] = *opt_int;
                                 }
-                                term.print("{}<t:bold><fg:cyan>{} ({}: {})<t:normal>: {} = ",
+                                term.print("{}<bold><fg:cyan>{} ({}: {})<normal>: {} = ",
                                            std::string(indent, ' '),
                                            int(it.key), schema_member->name, schema_member->type,
                                            type_to_cstr(it.type));
                             } else {
-                                term.print("{}<t:bold><fg:cyan>{}<t:normal>: {} = ",
+                                term.print("{}<bold><fg:cyan>{}<normal>: {} = ",
                                            std::string(indent, ' '),
                                            int(it.key), type_to_cstr(it.type));
                             }
@@ -198,9 +198,9 @@ int main(int argc, const char* argv[])
                                 uint32_t stored_crc = 0;
                                 std::memcpy(&stored_crc, it.data.get(), it.size);
                                 if (reader.crc() == stored_crc)
-                                    term.print(" <t:bold><fg:green>(CRC32: OK)<t:normal>");
+                                    term.print(" <bold><fg:green>(CRC32: OK)<normal>");
                                 else
-                                    term.print(" <t:bold><fg:red>(CRC32: expected {})<t:normal>",
+                                    term.print(" <bold><fg:red>(CRC32: expected {})<normal>",
                                             reader.crc());
                             }
                         }
@@ -214,13 +214,13 @@ int main(int argc, const char* argv[])
                     case What::LeaveGroup:
                         struct_stack.pop_back();
                         last_int_values.clear();
-                        term.print("<t:bold>{}}}<t:normal>\n", std::string(indent - 4, ' '));
+                        term.print("<bold>{}}}<normal>\n", std::string(indent - 4, ' '));
                         break;
                     case What::EnterMetadata:
-                        term.print("<t:bold>{}Metadata:<t:normal>\n", std::string(indent, ' '));
+                        term.print("<bold>{}Metadata:<normal>\n", std::string(indent, ' '));
                         break;
                     case What::LeaveMetadata:
-                        term.print("<t:bold>{}Data:<t:normal>\n", std::string(indent, ' '));
+                        term.print("<bold>{}Data:<normal>\n", std::string(indent, ' '));
                         break;
                     case What::EndOfFile:
                         eof = true;
@@ -228,7 +228,7 @@ int main(int argc, const char* argv[])
                 }
             }
         } catch (const ArchiveError& e) {
-            term.print("<t:bold><fg:red>{}<t:normal>\n", e.what());
+            term.print("<bold><fg:red>{}<normal>\n", e.what());
         }
     }
 

--- a/tools/find_file/ff.cpp
+++ b/tools/find_file/ff.cpp
@@ -979,8 +979,8 @@ int main(int argc, const char* argv[])
     } (argv);
 
     if (show_version) {
-        term.print("<t:bold>ff<t:normal> {}\n", c_version);
-        term.print("using <t:bold>Hyperscan<t:normal> {}\n", hs_version());
+        term.print("<bold>ff<normal> {}\n", c_version);
+        term.print("using <bold>Hyperscan<normal> {}\n", hs_version());
         return 0;
     }
 

--- a/tools/find_file/ff.cpp
+++ b/tools/find_file/ff.cpp
@@ -979,8 +979,8 @@ int main(int argc, const char* argv[])
     } (argv);
 
     if (show_version) {
-        term.print("{t:bold}ff{t:normal} {}\n", c_version);
-        term.print("using {t:bold}Hyperscan{t:normal} {}\n", hs_version());
+        term.print("<t:bold>ff<t:normal> {}\n", c_version);
+        term.print("using <t:bold>Hyperscan<t:normal> {}\n", hs_version());
         return 0;
     }
 

--- a/tools/fire_script/Highlighter.cpp
+++ b/tools/fire_script/Highlighter.cpp
@@ -1,7 +1,7 @@
 // Highlighter.cpp.cc created on 2021-03-03 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2021–2023 Radek Brich
+// Copyright 2021–2024 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Highlighter.h"
@@ -459,13 +459,13 @@ auto Highlighter::highlight(std::string_view input, unsigned cursor) -> HlResult
     try {
         auto root = tao::pegtl::parse_tree::parse< Main, Node, HighlightSelector, tao::pegtl::nothing, Control >( in );
         if (root->children.size() != 1)
-            return {std::string{input} + m_term.format("\n{fg:*red}{t:bold}highlighter parse error:{t:normal} {fg:*red}no match{t:normal}"), false};
+            return {std::string{input} + m_term.format("\n<fg:*red><t:bold>highlighter parse error:<t:normal> <fg:*red>no match<t:normal>"), false};
         auto last_color = highlight_node(*root->children[0], HighlightColor{}, cursor);
         switch_color(last_color, HighlightColor{});
         return {m_output, m_open_bracket};
     } catch (tao::pegtl::parse_error& e) {
         // The grammar is build in a way that parse error should never happen
-        return {std::string{input} + m_term.format("\n{fg:*red}{t:bold}highlighter parse error:{t:normal} {fg:*red}{}{t:normal}", e.what()), false};
+        return {std::string{input} + m_term.format("\n<fg:*red><t:bold>highlighter parse error:<t:normal> <fg:*red>{}<t:normal>", e.what()), false};
     }
 }
 

--- a/tools/fire_script/Highlighter.cpp
+++ b/tools/fire_script/Highlighter.cpp
@@ -459,13 +459,13 @@ auto Highlighter::highlight(std::string_view input, unsigned cursor) -> HlResult
     try {
         auto root = tao::pegtl::parse_tree::parse< Main, Node, HighlightSelector, tao::pegtl::nothing, Control >( in );
         if (root->children.size() != 1)
-            return {std::string{input} + m_term.format("\n<fg:*red><t:bold>highlighter parse error:<t:normal> <fg:*red>no match<t:normal>"), false};
+            return {std::string{input} + m_term.format("\n<fg:*red><bold>highlighter parse error:<normal> <fg:*red>no match<normal>"), false};
         auto last_color = highlight_node(*root->children[0], HighlightColor{}, cursor);
         switch_color(last_color, HighlightColor{});
         return {m_output, m_open_bracket};
     } catch (tao::pegtl::parse_error& e) {
         // The grammar is build in a way that parse error should never happen
-        return {std::string{input} + m_term.format("\n<fg:*red><t:bold>highlighter parse error:<t:normal> <fg:*red>{}<t:normal>", e.what()), false};
+        return {std::string{input} + m_term.format("\n<fg:*red><bold>highlighter parse error:<normal> <fg:*red>{}<normal>", e.what()), false};
     }
 }
 

--- a/tools/fire_script/Highlighter.cpp
+++ b/tools/fire_script/Highlighter.cpp
@@ -459,13 +459,13 @@ auto Highlighter::highlight(std::string_view input, unsigned cursor) -> HlResult
     try {
         auto root = tao::pegtl::parse_tree::parse< Main, Node, HighlightSelector, tao::pegtl::nothing, Control >( in );
         if (root->children.size() != 1)
-            return {std::string{input} + m_term.format("\n<fg:*red><bold>highlighter parse error:<normal> <fg:*red>no match<normal>"), false};
+            return {std::string{input} + m_term.format("\n<*red><bold>highlighter parse error:<normal> <*red>no match<normal>"), false};
         auto last_color = highlight_node(*root->children[0], HighlightColor{}, cursor);
         switch_color(last_color, HighlightColor{});
         return {m_output, m_open_bracket};
     } catch (tao::pegtl::parse_error& e) {
         // The grammar is build in a way that parse error should never happen
-        return {std::string{input} + m_term.format("\n<fg:*red><bold>highlighter parse error:<normal> <fg:*red>{}<normal>", e.what()), false};
+        return {std::string{input} + m_term.format("\n<*red><bold>highlighter parse error:<normal> <*red>{}<normal>", e.what()), false};
     }
 }
 

--- a/tools/fire_script/Options.cpp
+++ b/tools/fire_script/Options.cpp
@@ -58,11 +58,11 @@ static Flags pass_name_to_flag(std::string_view name)
     }) | to< std::vector<PassItem> >();
     auto& t = TermCtl::stderr_instance();
     if (filtered.empty()) {
-        t.print("{t:bold}Note:{t:normal} {} did not match any pass name\n", name);
+        t.print("<t:bold>Note:<t:normal> {} did not match any pass name\n", name);
         return Flags(~0);
     }
     if (filtered.size() > 1) {
-        t.print("{t:bold}Note:{t:normal} {} matched multiple pass names: {}\n",
+        t.print("<t:bold>Note:<t:normal> {} matched multiple pass names: {}\n",
                    name, fmt::join(filtered | keys, " "));
         return Flags(~0);
     }

--- a/tools/fire_script/Options.cpp
+++ b/tools/fire_script/Options.cpp
@@ -58,11 +58,11 @@ static Flags pass_name_to_flag(std::string_view name)
     }) | to< std::vector<PassItem> >();
     auto& t = TermCtl::stderr_instance();
     if (filtered.empty()) {
-        t.print("<t:bold>Note:<t:normal> {} did not match any pass name\n", name);
+        t.print("<bold>Note:<normal> {} did not match any pass name\n", name);
         return Flags(~0);
     }
     if (filtered.size() > 1) {
-        t.print("<t:bold>Note:<t:normal> {} matched multiple pass names: {}\n",
+        t.print("<bold>Note:<normal> {} matched multiple pass names: {}\n",
                    name, fmt::join(filtered | keys, " "));
         return Flags(~0);
     }

--- a/tools/fire_script/Program.cpp
+++ b/tools/fire_script/Program.cpp
@@ -1,7 +1,7 @@
 // Program.cpp.cc created on 2021-03-20 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2021–2023 Radek Brich
+// Copyright 2021–2024 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "Program.h"
@@ -18,9 +18,9 @@ namespace xci::script::tool {
 using namespace xci::core;
 
 static constexpr const char* intro =
-        "{t:bold}{fg:magenta}🔥 fire script{t:normal} {fg:magenta}v{}{t:normal}\n"
-        "Type {t:bold}{fg:yellow}.h{t:normal} for help, {t:bold}{fg:yellow}.q{t:normal} to quit.\n";
-static constexpr const char* prompt = "{fg:green}_{}>{t:normal} ";
+        "<t:bold><fg:magenta>🔥 fire script<t:normal> <fg:magenta>v{}<t:normal>\n"
+        "Type <t:bold><fg:yellow>.h<t:normal> for help, <t:bold><fg:yellow>.q<t:normal> to quit.\n";
+static constexpr const char* prompt = "<fg:green>_{}><t:normal> ";
 
 
 Program::Program(bool log_debug)
@@ -171,10 +171,10 @@ void Program::evaluate_input(std::string_view input)
             repl_command().eval(input.substr(1));
         } catch (const ScriptError& e) {
             auto& tout = ctx.term_out;
-            tout.print("{fg:red}{}: {t:bold}{}{t:normal}\n", e.code(), e.what());
+            tout.print("<fg:red>{}: <t:bold>{}<t:normal>\n", e.code(), e.what());
             if (!e.detail().empty())
-                tout.print("{fg:magenta}{}{t:normal}\n", e.detail());
-            tout.print("{fg:yellow}Help: .h | .help{t:normal}\n");
+                tout.print("<fg:magenta>{}<t:normal>\n", e.detail());
+            tout.print("<fg:yellow>Help: .h | .help<t:normal>\n");
         }
         return;
     }

--- a/tools/fire_script/Program.cpp
+++ b/tools/fire_script/Program.cpp
@@ -18,9 +18,9 @@ namespace xci::script::tool {
 using namespace xci::core;
 
 static constexpr const char* intro =
-        "<t:bold><fg:magenta>🔥 fire script<t:normal> <fg:magenta>v{}<t:normal>\n"
-        "Type <t:bold><fg:yellow>.h<t:normal> for help, <t:bold><fg:yellow>.q<t:normal> to quit.\n";
-static constexpr const char* prompt = "<fg:green>_{}><t:normal> ";
+        "<bold><fg:magenta>🔥 fire script<normal> <fg:magenta>v{}<normal>\n"
+        "Type <bold><fg:yellow>.h<normal> for help, <bold><fg:yellow>.q<normal> to quit.\n";
+static constexpr const char* prompt = "<fg:green>_{}><normal> ";
 
 
 Program::Program(bool log_debug)
@@ -171,10 +171,10 @@ void Program::evaluate_input(std::string_view input)
             repl_command().eval(input.substr(1));
         } catch (const ScriptError& e) {
             auto& tout = ctx.term_out;
-            tout.print("<fg:red>{}: <t:bold>{}<t:normal>\n", e.code(), e.what());
+            tout.print("<fg:red>{}: <bold>{}<normal>\n", e.code(), e.what());
             if (!e.detail().empty())
-                tout.print("<fg:magenta>{}<t:normal>\n", e.detail());
-            tout.print("<fg:yellow>Help: .h | .help<t:normal>\n");
+                tout.print("<fg:magenta>{}<normal>\n", e.detail());
+            tout.print("<fg:yellow>Help: .h | .help<normal>\n");
         }
         return;
     }

--- a/tools/fire_script/Program.cpp
+++ b/tools/fire_script/Program.cpp
@@ -18,9 +18,9 @@ namespace xci::script::tool {
 using namespace xci::core;
 
 static constexpr const char* intro =
-        "<bold><fg:magenta>🔥 fire script<normal> <fg:magenta>v{}<normal>\n"
-        "Type <bold><fg:yellow>.h<normal> for help, <bold><fg:yellow>.q<normal> to quit.\n";
-static constexpr const char* prompt = "<fg:green>_{}><normal> ";
+        "<bold><magenta>🔥 fire script<normal> <magenta>v{}<normal>\n"
+        "Type <bold><yellow>.h<normal> for help, <bold><yellow>.q<normal> to quit.\n";
+static constexpr const char* prompt = "<green>_{}><normal> ";
 
 
 Program::Program(bool log_debug)
@@ -171,10 +171,10 @@ void Program::evaluate_input(std::string_view input)
             repl_command().eval(input.substr(1));
         } catch (const ScriptError& e) {
             auto& tout = ctx.term_out;
-            tout.print("<fg:red>{}: <bold>{}<normal>\n", e.code(), e.what());
+            tout.print("<red>{}: <bold>{}<normal>\n", e.code(), e.what());
             if (!e.detail().empty())
-                tout.print("<fg:magenta>{}<normal>\n", e.detail());
-            tout.print("<fg:yellow>Help: .h | .help<normal>\n");
+                tout.print("<magenta>{}<normal>\n", e.detail());
+            tout.print("<yellow>Help: .h | .help<normal>\n");
         }
         return;
     }

--- a/tools/fire_script/Repl.cpp
+++ b/tools/fire_script/Repl.cpp
@@ -150,7 +150,7 @@ bool Repl::evaluate_module(Module& module, EvalMode mode)
         machine.call(main_fn, [&](TypedValue&& invoked) {
             if (!invoked.is_void()) {
                 t.sanitize_newline();
-                t.print("<t:bold><fg:yellow>{}<t:normal>\n", invoked);
+                t.print("<bold><fg:yellow>{}<normal>\n", invoked);
             }
             invoked.decref();
         });
@@ -163,14 +163,14 @@ bool Repl::evaluate_module(Module& module, EvalMode mode)
             // REPL mode
             const auto& module_name = module.name();
             if (!result.is_void()) {
-                t.print("<t:bold><fg:magenta>{}:{} = <fg:default>{}<t:normal>\n",
+                t.print("<bold><fg:magenta>{}:{} = <fg:default>{}<normal>\n",
                         module_name, result.type_info(), result);
             }
         } else {
             // single input mode
             assert(mode == EvalMode::SingleInput);
             if (!result.is_void()) {
-                t.print("<t:bold>{}<t:normal>\n", result);
+                t.print("<bold>{}<normal>\n", result);
             }
         }
         result.decref();
@@ -191,9 +191,9 @@ void Repl::print_error(const ScriptError& e)
 
     if (!e.file().empty())
         t.print("{}: ", e.file());
-    t.print("<fg:red><t:bold>{}: <fg:*white><t:normal_intensity>{}<t:normal>", e.code(), e.what());
+    t.print("<fg:red><bold>{}: <fg:*white><normal_intensity>{}<normal>", e.code(), e.what());
     if (!e.detail().empty())
-        t.print("\n<fg:magenta>{}<t:normal>", e.detail());
+        t.print("\n<fg:magenta>{}<normal>", e.detail());
     t.write_nl();
 }
 

--- a/tools/fire_script/Repl.cpp
+++ b/tools/fire_script/Repl.cpp
@@ -150,7 +150,7 @@ bool Repl::evaluate_module(Module& module, EvalMode mode)
         machine.call(main_fn, [&](TypedValue&& invoked) {
             if (!invoked.is_void()) {
                 t.sanitize_newline();
-                t.print("<bold><fg:yellow>{}<normal>\n", invoked);
+                t.print("<bold><yellow>{}<normal>\n", invoked);
             }
             invoked.decref();
         });
@@ -163,7 +163,7 @@ bool Repl::evaluate_module(Module& module, EvalMode mode)
             // REPL mode
             const auto& module_name = module.name();
             if (!result.is_void()) {
-                t.print("<bold><fg:magenta>{}:{} = <fg:default>{}<normal>\n",
+                t.print("<bold><magenta>{}:{} = <default>{}<normal>\n",
                         module_name, result.type_info(), result);
             }
         } else {
@@ -191,9 +191,9 @@ void Repl::print_error(const ScriptError& e)
 
     if (!e.file().empty())
         t.print("{}: ", e.file());
-    t.print("<fg:red><bold>{}: <fg:*white><normal_intensity>{}<normal>", e.code(), e.what());
+    t.print("<red><bold>{}: <*white><normal_intensity>{}<normal>", e.code(), e.what());
     if (!e.detail().empty())
-        t.print("\n<fg:magenta>{}<normal>", e.detail());
+        t.print("\n<magenta>{}<normal>", e.detail());
     t.write_nl();
 }
 

--- a/tools/fire_script/Repl.cpp
+++ b/tools/fire_script/Repl.cpp
@@ -150,7 +150,7 @@ bool Repl::evaluate_module(Module& module, EvalMode mode)
         machine.call(main_fn, [&](TypedValue&& invoked) {
             if (!invoked.is_void()) {
                 t.sanitize_newline();
-                t.print("{t:bold}{fg:yellow}{}{t:normal}\n", invoked);
+                t.print("<t:bold><fg:yellow>{}<t:normal>\n", invoked);
             }
             invoked.decref();
         });
@@ -163,14 +163,14 @@ bool Repl::evaluate_module(Module& module, EvalMode mode)
             // REPL mode
             const auto& module_name = module.name();
             if (!result.is_void()) {
-                t.print("{t:bold}{fg:magenta}{}:{} = {fg:default}{}{t:normal}\n",
+                t.print("<t:bold><fg:magenta>{}:{} = <fg:default>{}<t:normal>\n",
                         module_name, result.type_info(), result);
             }
         } else {
             // single input mode
             assert(mode == EvalMode::SingleInput);
             if (!result.is_void()) {
-                t.print("{t:bold}{}{t:normal}\n", result);
+                t.print("<t:bold>{}<t:normal>\n", result);
             }
         }
         result.decref();
@@ -191,9 +191,9 @@ void Repl::print_error(const ScriptError& e)
 
     if (!e.file().empty())
         t.print("{}: ", e.file());
-    t.print("{fg:red}{t:bold}{}: {fg:*white}{t:normal_intensity}{}{t:normal}", e.code(), e.what());
+    t.print("<fg:red><t:bold>{}: <fg:*white><t:normal_intensity>{}<t:normal>", e.code(), e.what());
     if (!e.detail().empty())
-        t.print("\n{fg:magenta}{}{t:normal}", e.detail());
+        t.print("\n<fg:magenta>{}<t:normal>", e.detail());
     t.write_nl();
 }
 

--- a/tools/fire_script/ReplCommand.cpp
+++ b/tools/fire_script/ReplCommand.cpp
@@ -76,7 +76,7 @@ const Module* ReplCommand::module_by_idx(Index mod_idx) {
         return m_module.get();
 
     if (mod_idx >= m_ctx.input_modules.size()) {
-        t.print("<t:bold><fg:red>Error: module index out of range: {}<t:normal>\n",
+        t.print("<bold><fg:red>Error: module index out of range: {}<normal>\n",
                 mod_idx);
         return nullptr;
     }
@@ -100,7 +100,7 @@ const Module* ReplCommand::module_by_name(std::string_view mod_name) {
     }
 
     TermCtl& t = m_ctx.term_out;
-    t.print("<t:bold><fg:red>Error: module not found: {}<t:normal>\n",
+    t.print("<bold><fg:red>Error: module not found: {}<normal>\n",
             mod_name);
     return nullptr;
 }
@@ -138,7 +138,7 @@ void ReplCommand::dump_function(const Module& mod, Index fun_idx) {
     TermCtl& t = m_ctx.term_out;
 
     if (fun_idx >= mod.num_functions()) {
-        t.print("<t:bold><fg:red>Error: function index out of range: {}<t:normal>\n",
+        t.print("<bold><fg:red>Error: function index out of range: {}<normal>\n",
                 fun_idx);
         return;
     }
@@ -153,14 +153,14 @@ void ReplCommand::dump_function(const Module& mod, Index fun_idx) {
 void ReplCommand::cmd_dump_function() {
     TermCtl& t = m_ctx.term_out;
     if (m_ctx.input_modules.empty()) {
-        t.print("<t:bold><fg:red>Error: no input modules available<t:normal>\n");
+        t.print("<bold><fg:red>Error: no input modules available<normal>\n");
         return;
     }
     size_t mod_idx = m_ctx.input_modules.size() - 1;
     const auto& mod = *m_ctx.input_modules[mod_idx];
 
     if (mod.num_functions() == 0) {
-        t.print("<t:bold><fg:red>Error: no functions available<t:normal>\n");
+        t.print("<bold><fg:red>Error: no functions available<normal>\n");
         return;
     }
 
@@ -171,7 +171,7 @@ void ReplCommand::cmd_dump_function() {
 void ReplCommand::cmd_dump_function(std::string_view fun_name) {
     TermCtl& t = m_ctx.term_out;
     if (m_ctx.input_modules.empty()) {
-        t.print("<t:bold><fg:red>Error: no input modules available<t:normal>\n");
+        t.print("<bold><fg:red>Error: no input modules available<normal>\n");
         return;
     }
     size_t mod_idx = m_ctx.input_modules.size() - 1;
@@ -184,7 +184,7 @@ void ReplCommand::cmd_dump_function(std::string_view fun_name) {
             return;
         }
     }
-    t.print("<t:bold><fg:red>Error: function not found: {}<t:normal>\n",
+    t.print("<bold><fg:red>Error: function not found: {}<normal>\n",
             fun_name);
 }
 
@@ -205,7 +205,7 @@ void ReplCommand::cmd_dump_function(std::string_view fun_name, std::string_view 
             return;
         }
     }
-    t.print("<t:bold><fg:red>Error: function not found: {}<t:normal>\n",
+    t.print("<bold><fg:red>Error: function not found: {}<normal>\n",
             fun_name);
 }
 
@@ -214,7 +214,7 @@ void ReplCommand::cmd_dump_function(Index fun_idx)
 {
     TermCtl& t = m_ctx.term_out;
     if (m_ctx.input_modules.empty()) {
-        t.print("<t:bold><fg:red>Error: no modules available<t:normal>\n");
+        t.print("<bold><fg:red>Error: no modules available<normal>\n");
         return;
     }
     size_t mod_idx = m_ctx.input_modules.size() - 1;
@@ -274,7 +274,7 @@ void ReplCommand::cmd_describe(std::string_view name) {
                 return;
         }
     }
-    t.print("<t:bold><fg:red>Error: symbol not found: {}<t:normal>\n",
+    t.print("<bold><fg:red>Error: symbol not found: {}<normal>\n",
             name);
 }
 

--- a/tools/fire_script/ReplCommand.cpp
+++ b/tools/fire_script/ReplCommand.cpp
@@ -1,7 +1,7 @@
 // ReplCommand.cpp created on 2020-01-11 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2020–2023 Radek Brich
+// Copyright 2020–2024 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include "ReplCommand.h"
@@ -76,7 +76,7 @@ const Module* ReplCommand::module_by_idx(Index mod_idx) {
         return m_module.get();
 
     if (mod_idx >= m_ctx.input_modules.size()) {
-        t.print("{t:bold}{fg:red}Error: module index out of range: {}{t:normal}\n",
+        t.print("<t:bold><fg:red>Error: module index out of range: {}<t:normal>\n",
                 mod_idx);
         return nullptr;
     }
@@ -100,7 +100,7 @@ const Module* ReplCommand::module_by_name(std::string_view mod_name) {
     }
 
     TermCtl& t = m_ctx.term_out;
-    t.print("{t:bold}{fg:red}Error: module not found: {}{t:normal}\n",
+    t.print("<t:bold><fg:red>Error: module not found: {}<t:normal>\n",
             mod_name);
     return nullptr;
 }
@@ -138,7 +138,7 @@ void ReplCommand::dump_function(const Module& mod, Index fun_idx) {
     TermCtl& t = m_ctx.term_out;
 
     if (fun_idx >= mod.num_functions()) {
-        t.print("{t:bold}{fg:red}Error: function index out of range: {}{t:normal}\n",
+        t.print("<t:bold><fg:red>Error: function index out of range: {}<t:normal>\n",
                 fun_idx);
         return;
     }
@@ -153,14 +153,14 @@ void ReplCommand::dump_function(const Module& mod, Index fun_idx) {
 void ReplCommand::cmd_dump_function() {
     TermCtl& t = m_ctx.term_out;
     if (m_ctx.input_modules.empty()) {
-        t.print("{t:bold}{fg:red}Error: no input modules available{t:normal}\n");
+        t.print("<t:bold><fg:red>Error: no input modules available<t:normal>\n");
         return;
     }
     size_t mod_idx = m_ctx.input_modules.size() - 1;
     const auto& mod = *m_ctx.input_modules[mod_idx];
 
     if (mod.num_functions() == 0) {
-        t.print("{t:bold}{fg:red}Error: no functions available{t:normal}\n");
+        t.print("<t:bold><fg:red>Error: no functions available<t:normal>\n");
         return;
     }
 
@@ -171,7 +171,7 @@ void ReplCommand::cmd_dump_function() {
 void ReplCommand::cmd_dump_function(std::string_view fun_name) {
     TermCtl& t = m_ctx.term_out;
     if (m_ctx.input_modules.empty()) {
-        t.print("{t:bold}{fg:red}Error: no input modules available{t:normal}\n");
+        t.print("<t:bold><fg:red>Error: no input modules available<t:normal>\n");
         return;
     }
     size_t mod_idx = m_ctx.input_modules.size() - 1;
@@ -184,7 +184,7 @@ void ReplCommand::cmd_dump_function(std::string_view fun_name) {
             return;
         }
     }
-    t.print("{t:bold}{fg:red}Error: function not found: {}{t:normal}\n",
+    t.print("<t:bold><fg:red>Error: function not found: {}<t:normal>\n",
             fun_name);
 }
 
@@ -205,7 +205,7 @@ void ReplCommand::cmd_dump_function(std::string_view fun_name, std::string_view 
             return;
         }
     }
-    t.print("{t:bold}{fg:red}Error: function not found: {}{t:normal}\n",
+    t.print("<t:bold><fg:red>Error: function not found: {}<t:normal>\n",
             fun_name);
 }
 
@@ -214,7 +214,7 @@ void ReplCommand::cmd_dump_function(Index fun_idx)
 {
     TermCtl& t = m_ctx.term_out;
     if (m_ctx.input_modules.empty()) {
-        t.print("{t:bold}{fg:red}Error: no modules available{t:normal}\n");
+        t.print("<t:bold><fg:red>Error: no modules available<t:normal>\n");
         return;
     }
     size_t mod_idx = m_ctx.input_modules.size() - 1;
@@ -274,7 +274,7 @@ void ReplCommand::cmd_describe(std::string_view name) {
                 return;
         }
     }
-    t.print("{t:bold}{fg:red}Error: symbol not found: {}{t:normal}\n",
+    t.print("<t:bold><fg:red>Error: symbol not found: {}<t:normal>\n",
             name);
 }
 

--- a/tools/fire_script/ReplCommand.cpp
+++ b/tools/fire_script/ReplCommand.cpp
@@ -76,7 +76,7 @@ const Module* ReplCommand::module_by_idx(Index mod_idx) {
         return m_module.get();
 
     if (mod_idx >= m_ctx.input_modules.size()) {
-        t.print("<bold><fg:red>Error: module index out of range: {}<normal>\n",
+        t.print("<bold><red>Error: module index out of range: {}<normal>\n",
                 mod_idx);
         return nullptr;
     }
@@ -100,7 +100,7 @@ const Module* ReplCommand::module_by_name(std::string_view mod_name) {
     }
 
     TermCtl& t = m_ctx.term_out;
-    t.print("<bold><fg:red>Error: module not found: {}<normal>\n",
+    t.print("<bold><red>Error: module not found: {}<normal>\n",
             mod_name);
     return nullptr;
 }
@@ -138,7 +138,7 @@ void ReplCommand::dump_function(const Module& mod, Index fun_idx) {
     TermCtl& t = m_ctx.term_out;
 
     if (fun_idx >= mod.num_functions()) {
-        t.print("<bold><fg:red>Error: function index out of range: {}<normal>\n",
+        t.print("<bold><red>Error: function index out of range: {}<normal>\n",
                 fun_idx);
         return;
     }
@@ -153,14 +153,14 @@ void ReplCommand::dump_function(const Module& mod, Index fun_idx) {
 void ReplCommand::cmd_dump_function() {
     TermCtl& t = m_ctx.term_out;
     if (m_ctx.input_modules.empty()) {
-        t.print("<bold><fg:red>Error: no input modules available<normal>\n");
+        t.print("<bold><red>Error: no input modules available<normal>\n");
         return;
     }
     size_t mod_idx = m_ctx.input_modules.size() - 1;
     const auto& mod = *m_ctx.input_modules[mod_idx];
 
     if (mod.num_functions() == 0) {
-        t.print("<bold><fg:red>Error: no functions available<normal>\n");
+        t.print("<bold><red>Error: no functions available<normal>\n");
         return;
     }
 
@@ -171,7 +171,7 @@ void ReplCommand::cmd_dump_function() {
 void ReplCommand::cmd_dump_function(std::string_view fun_name) {
     TermCtl& t = m_ctx.term_out;
     if (m_ctx.input_modules.empty()) {
-        t.print("<bold><fg:red>Error: no input modules available<normal>\n");
+        t.print("<bold><red>Error: no input modules available<normal>\n");
         return;
     }
     size_t mod_idx = m_ctx.input_modules.size() - 1;
@@ -184,7 +184,7 @@ void ReplCommand::cmd_dump_function(std::string_view fun_name) {
             return;
         }
     }
-    t.print("<bold><fg:red>Error: function not found: {}<normal>\n",
+    t.print("<bold><red>Error: function not found: {}<normal>\n",
             fun_name);
 }
 
@@ -205,7 +205,7 @@ void ReplCommand::cmd_dump_function(std::string_view fun_name, std::string_view 
             return;
         }
     }
-    t.print("<bold><fg:red>Error: function not found: {}<normal>\n",
+    t.print("<bold><red>Error: function not found: {}<normal>\n",
             fun_name);
 }
 
@@ -214,7 +214,7 @@ void ReplCommand::cmd_dump_function(Index fun_idx)
 {
     TermCtl& t = m_ctx.term_out;
     if (m_ctx.input_modules.empty()) {
-        t.print("<bold><fg:red>Error: no modules available<normal>\n");
+        t.print("<bold><red>Error: no modules available<normal>\n");
         return;
     }
     size_t mod_idx = m_ctx.input_modules.size() - 1;
@@ -274,7 +274,7 @@ void ReplCommand::cmd_describe(std::string_view name) {
                 return;
         }
     }
-    t.print("<bold><fg:red>Error: symbol not found: {}<normal>\n",
+    t.print("<bold><red>Error: symbol not found: {}<normal>\n",
             name);
 }
 

--- a/tools/shader_editor/shed.cpp
+++ b/tools/shader_editor/shed.cpp
@@ -1,7 +1,7 @@
 // shed.cpp created on 2023-02-21 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2023 Radek Brich
+// Copyright 2023–2024 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 /// Shader Editor (shed) tool
@@ -81,7 +81,7 @@ int main(int argc, const char* argv[])
     Logger::init(log_debug ? Logger::Level::Trace : Logger::Level::Warning);
 
     if (show_version) {
-        term.print("{t:bold}shed{t:normal} {fg:*white}{}{t:normal}\n", c_version);
+        term.print("<t:bold>shed<t:normal> <fg:*white>{}<t:normal>\n", c_version);
         return 0;
     }
 

--- a/tools/shader_editor/shed.cpp
+++ b/tools/shader_editor/shed.cpp
@@ -81,7 +81,7 @@ int main(int argc, const char* argv[])
     Logger::init(log_debug ? Logger::Level::Trace : Logger::Level::Warning);
 
     if (show_version) {
-        term.print("<t:bold>shed<t:normal> <fg:*white>{}<t:normal>\n", c_version);
+        term.print("<bold>shed<normal> <fg:*white>{}<normal>\n", c_version);
         return 0;
     }
 

--- a/tools/shader_editor/shed.cpp
+++ b/tools/shader_editor/shed.cpp
@@ -81,7 +81,7 @@ int main(int argc, const char* argv[])
     Logger::init(log_debug ? Logger::Level::Trace : Logger::Level::Warning);
 
     if (show_version) {
-        term.print("<bold>shed<normal> <fg:*white>{}<normal>\n", c_version);
+        term.print("<bold>shed<normal> <*white>{}<normal>\n", c_version);
         return 0;
     }
 

--- a/tools/term_ctl/tc.cpp
+++ b/tools/term_ctl/tc.cpp
@@ -1,7 +1,7 @@
 // tc.cpp created on 2022-10-09 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2022 Radek Brich
+// Copyright 2022–2024 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 /// Term Ctl (tc) command line tool
@@ -33,7 +33,7 @@ int main(int argc, const char* argv[])
     TermCtl term(STDOUT_FILENO, isatty_always ? TermCtl::IsTty::Always : TermCtl::IsTty::Auto);
 
     if (show_version) {
-        term.print("{t:bold}tc{t:normal} {}\n", c_version);
+        term.print("<t:bold>tc<t:normal> {}\n", c_version);
         return 0;
     }
 

--- a/tools/term_ctl/tc.cpp
+++ b/tools/term_ctl/tc.cpp
@@ -33,7 +33,7 @@ int main(int argc, const char* argv[])
     TermCtl term(STDOUT_FILENO, isatty_always ? TermCtl::IsTty::Always : TermCtl::IsTty::Auto);
 
     if (show_version) {
-        term.print("<t:bold>tc<t:normal> {}\n", c_version);
+        term.print("<bold>tc<normal> {}\n", c_version);
         return 0;
     }
 


### PR DESCRIPTION
Do not delegate to fmt. There is a regression in fmt 11, which broke that - named placeholders cannot be mixed with automatically indexed ones. Although I think this should be allowed, using the named args for the TermCtl color placeholders was basically a hack. A custom parser will be more flexible and allow more freedom regarding the syntax.

The new placeholders are processed purely in runtime. Unknown placeholders are left untouched. Compile-time checking is still possible, but that doesn't seem as important feature. Actual replacing by escape sequences must be done in runtime, as it depends on what is attached to the output stream (tty or pipe).

New syntax:
```
<bold>bold text<normal>
<b>shortcut attrs<n>
<red><@blue>red text on blue background<n>
<*white>intense white text<n>
```

* [x] Escaping for the opening `<`, e.g. `"\<"`
* [x] Drop the `fg:`, make it default - e.g. `<red>`
* [x] Drop the `bg:`, use different syntax for that, e.g. `<@blue>` (blue background), ~`<red@blue>` (red text on blue background)~
