### PR TITLE
[graphics] Fix Vulkan validation error on vkAcquireNextImageKHR

### DIFF
--- a/src/xci/graphics/Renderer.cpp
+++ b/src/xci/graphics/Renderer.cpp
@@ -118,13 +118,7 @@ bool Renderer::create_instance(SDL_Window* window)
     };
 
     std::vector<const char *> extensions;
-    {
-        unsigned int sdlExtensionCount = 0;
-        SDL_Vulkan_GetInstanceExtensions(window, &sdlExtensionCount, nullptr);
-        extensions.resize(sdlExtensionCount);
-        SDL_Vulkan_GetInstanceExtensions(window, &sdlExtensionCount, extensions.data());
-        extensions.resize(sdlExtensionCount);
-    }
+    vk_get_vector(extensions, SDL_Vulkan_GetInstanceExtensions, window);
 
 #ifdef XCI_DEBUG_VULKAN
     // enable validation layers

--- a/src/xci/graphics/Window.cpp
+++ b/src/xci/graphics/Window.cpp
@@ -513,6 +513,13 @@ void Window::resize_framebuffer()
 
 void Window::draw()
 {
+    VK_TRY("vkWaitForFences",
+            vkWaitForFences(m_renderer.vk_device(),
+                    1, &m_cmd_buf_fences[m_current_cmd_buf], VK_TRUE, UINT64_MAX));
+    VK_TRY("vkResetFences",
+            vkResetFences(m_renderer.vk_device(),
+                    1, &m_cmd_buf_fences[m_current_cmd_buf]));
+
     uint32_t image_index;
     auto rc = vkAcquireNextImageKHR(m_renderer.vk_device(),
             m_renderer.vk_swapchain(), UINT64_MAX,
@@ -530,13 +537,6 @@ void Window::draw()
     }
 
     {
-        VK_TRY("vkWaitForFences",
-                vkWaitForFences(m_renderer.vk_device(),
-                        1, &m_cmd_buf_fences[m_current_cmd_buf], VK_TRUE, UINT64_MAX));
-        VK_TRY("vkResetFences",
-                vkResetFences(m_renderer.vk_device(),
-                        1, &m_cmd_buf_fences[m_current_cmd_buf]));
-
         m_command_buffers[m_current_cmd_buf].release_resources();
 
         auto& cmd_buf = m_command_buffers[m_current_cmd_buf];

--- a/src/xci/graphics/vulkan/Framebuffer.h
+++ b/src/xci/graphics/vulkan/Framebuffer.h
@@ -19,29 +19,29 @@ class Attachments;
 
 class Framebuffer {
 public:
-    static constexpr uint32_t max_image_count = 8;
-
     explicit Framebuffer(Renderer& renderer)
             : m_renderer(renderer), m_image_memory(renderer) {}
     ~Framebuffer() { destroy(); }
 
+    /// \param image_count - Number of color buffers
     void create(const Attachments& attachments, VkExtent2D size, uint32_t image_count,
                 VkImage* swapchain_images = nullptr);
     void destroy();
 
-    VkImage color_image(uint32_t buffer, uint32_t image_index) const { return m_images[buffer * m_image_count + image_index]; }
-    VkImageView color_image_view(uint32_t buffer, uint32_t image_index) const { return m_image_views[buffer * m_image_count + image_index].vk(); }
+    uint32_t color_image_count() const { return m_framebuffers.size(); }
+    VkImage color_image(uint32_t buffer, uint32_t image_index) const { return m_images[buffer * m_framebuffers.size() + image_index]; }
+    VkImageView color_image_view(uint32_t buffer, uint32_t image_index) const { return m_image_views[buffer * m_framebuffers.size() + image_index].vk(); }
 
     VkFramebuffer vk_framebuffer(uint32_t index) const { return m_framebuffers[index]; }
     VkFramebuffer operator[](uint32_t index) const { return m_framebuffers[index]; }
 
-    Renderer& renderer() { return m_renderer; }
+    Renderer& renderer() const { return m_renderer; }
 
 private:
     VkDeviceSize create_image(const ImageCreateInfo& image_ci, VkImage& image);
 
     Renderer& m_renderer;
-    VkFramebuffer m_framebuffers[max_image_count] {};
+    std::vector<VkFramebuffer> m_framebuffers;
     DeviceMemory m_image_memory;
 
     // Images in following order and counts:
@@ -52,7 +52,6 @@ private:
     std::vector<VkImage> m_images;
     std::vector<ImageView> m_image_views;
 
-    uint32_t m_image_count = 0;  // <= max_image_count
     uint32_t m_borrowed_count = 0; // number of borrowed swapchain images (at beginning of m_images)
 };
 

--- a/src/xci/graphics/vulkan/Swapchain.cpp
+++ b/src/xci/graphics/vulkan/Swapchain.cpp
@@ -80,13 +80,8 @@ void Swapchain::create()
     destroy();
     m_swapchain = new_swapchain;
 
-    TRACE("Vulkan: swapchain image count: {}", m_image_count);
-    vkGetSwapchainImagesKHR(device, m_swapchain, &m_image_count, nullptr);
-
-    if (m_image_count > Framebuffer::max_image_count)
-        VK_THROW("vulkan: too many swapchain images");
-
-    vkGetSwapchainImagesKHR(device, m_swapchain, &m_image_count, m_images);
+    vk_get_vector(m_images, vkGetSwapchainImagesKHR, device, m_swapchain);
+    TRACE("Vulkan: swapchain image count: {}", m_images.size());
 }
 
 
@@ -102,7 +97,7 @@ void Swapchain::destroy()
 
 void Swapchain::create_framebuffers()
 {
-    m_framebuffer.create(m_attachments, m_extent, m_image_count, m_images);
+    m_framebuffer.create(m_attachments, m_extent, m_images.size(), m_images.data());
 }
 
 

--- a/src/xci/graphics/vulkan/Swapchain.h
+++ b/src/xci/graphics/vulkan/Swapchain.h
@@ -12,6 +12,7 @@
 #include "Attachments.h"
 
 #include <vulkan/vulkan.h>
+#include <vector>
 
 namespace xci::graphics {
 
@@ -72,13 +73,13 @@ private:
 
     Attachments m_attachments;
 
-    VkImage m_images[Framebuffer::max_image_count] {};
+    std::vector<VkImage> m_images;
     Framebuffer m_framebuffer;
 
     // create info
     VkSurfaceFormatKHR m_surface_format {};
     VkExtent2D m_extent {};
-    uint32_t m_image_count = 0;  // <= max_image_count
+    uint32_t m_image_count = 0;  // recommended image count according to surface capabilities
     PresentMode m_present_mode = PresentMode::Fifo;
 };
 

--- a/src/xci/graphics/vulkan/VulkanError.h
+++ b/src/xci/graphics/vulkan/VulkanError.h
@@ -1,7 +1,7 @@
 // vulkan_error.h created on 2019-12-05 as part of xcikit project
 // https://github.com/rbrich/xcikit
 //
-// Copyright 2019–2023 Radek Brich
+// Copyright 2019–2024 Radek Brich
 // Licensed under the Apache License, Version 2.0 (see LICENSE file)
 
 #include <vulkan/vulkan_core.h>  // VkResult
@@ -105,6 +105,18 @@ inline void vk_log_error(std::string_view msg, enum VkResult vk_res)
 #define VK_TRY_RET(msg, expr) \
     do { if (const VkResult res = (expr); res != VK_SUCCESS) { vk_log_error(msg, res); return false; } } while(0)
 #endif
+
+
+/// Utility function to get vector data from Vulkan API
+template <typename VecT, typename F, typename... Args>
+auto vk_get_vector(VecT& res, F&& f, Args&&... args) {
+    uint32_t count;
+    f(args..., &count, nullptr);
+    res.resize(count);
+    const auto r = f(args..., &count, res.data());
+    res.resize(count);
+    return r;
+}
 
 
 } // namespace xci::graphics

--- a/xcikit-config.cmake.in
+++ b/xcikit-config.cmake.in
@@ -12,6 +12,10 @@ find_dependency(Threads)
 find_dependency(fmt)
 find_dependency(pegtl)
 
+if (NOT EMSCRIPTEN AND (@XCI_DATA@ OR @XCI_VFS@))
+    find_dependency(ZLIB)
+endif()
+
 if (@XCI_GRAPHICS@ OR @XCI_SCRIPT@)
     find_dependency(range-v3)
 endif()


### PR DESCRIPTION
> Semaphore must not have any pending operations. The Vulkan spec states: If semaphore is not VK_NULL_HANDLE it must not have any uncompleted signal or wait operations pending