### PR TITLE
[core] ArgParser - modernize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,12 +114,7 @@ jobs:
           clang: Xcode_16.1.0
           os_target: "15.0"
           build_args: ""
-        - os: windows-2019
-          name: "VS 16 / Release"
-          cc: msvc
-          cc_ver: 192
-          build_args: "--vcpkg -DCMAKE_DISABLE_PRECOMPILE_HEADERS=1"
-        - os: windows-2022
+        - os: windows-2025
           name: "VS 17 / Release"
           cc: msvc
           cc_ver: 194

--- a/src/xci/core/ArgParser.h
+++ b/src/xci/core/ArgParser.h
@@ -37,8 +37,8 @@ public:
 
 // integers
 template <class T>
-typename std::enable_if_t<std::is_integral_v<T> && !std::is_same_v<T, bool>, bool>
-value_from_cstr(const char* s, T& value)
+requires (std::is_integral_v<T> && !std::is_same_v<T, bool>)
+bool value_from_cstr(const char* s, T& value)
 {
     char* end;
     errno = 0;
@@ -53,8 +53,9 @@ value_from_cstr(const char* s, T& value)
 
 // bool
 template <class T>
-typename std::enable_if_t<std::is_same_v<T, bool>, bool>
-value_from_cstr(const char* s, T& value) {
+requires (std::is_same_v<T, bool>)
+bool value_from_cstr(const char* s, T& value)
+{
     if ((*s == '0' || tolower(*s) == 'f' || tolower(*s) == 'n') && s[1] == '\0')
         value = false;
     else if ((*s == '1' || tolower(*s) == 't' || tolower(*s) == 'y') && s[1] == '\0')
@@ -70,13 +71,12 @@ value_from_cstr(const char* s, T& value) {
 
 // const char* (original, unparsed C string)
 template <class T>
-typename std::enable_if_t<
-            std::is_same_v<T, const char*> || (
+requires (std::is_same_v<T, const char*> || (
                 std::is_assignable_v<T&, const char*> &&            // types with `operator=(const char*)`
                 !std::is_trivially_assignable_v<T&, const char*>    // exclude `bool& v = const char* u` etc.
-            ),
-        bool>
-value_from_cstr(const char* s, T& value) {
+            ))
+bool value_from_cstr(const char* s, T& value)
+{
     value = s;
     return true;
 }

--- a/src/xci/core/bit.h
+++ b/src/xci/core/bit.h
@@ -35,13 +35,11 @@ namespace xci::core {
 ///     auto b = bit_copy<uint16_t>(ptr + 4);
 
 template <class To, class From>
-typename std::enable_if<
-        std::is_trivially_copyable<From>::value &&
-        (std::is_trivial<To>::value || std::is_same_v<To, uint128>) &&
-        !std::is_pointer<From>::value &&
-        (sizeof(From) == 1 || sizeof(From) == sizeof(To)),
-        To>::type
-bit_copy(const From* src) noexcept
+requires (std::is_trivially_copyable_v<From> &&
+        (std::is_trivial_v<To> || std::is_same_v<To, uint128>) &&
+        !std::is_pointer_v<From> &&
+        (sizeof(From) == 1 || sizeof(From) == sizeof(To)))
+To bit_copy(const From* src) noexcept
 {
     To dst;
     std::memcpy(&dst, src, sizeof(To));


### PR DESCRIPTION
use `requires` instead of `std::enable_if`